### PR TITLE
FEAT: 공통 응답 및 Error 반환 로직 완성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,18 @@ repositories {
 }
 
 dependencies {
+	// BASIC
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	// TEST
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	runtimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/src/main/java/spot/spot/global/config/GlobalResponseHandler.java
+++ b/src/main/java/spot/spot/global/config/GlobalResponseHandler.java
@@ -1,0 +1,46 @@
+package spot.spot.global.config;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import spot.spot.global.dto.response.ResultResponse;
+import spot.spot.global.exception.ErrorCode;
+import spot.spot.global.exception.GlobalException;
+
+@RestControllerAdvice
+public class GlobalResponseHandler implements ResponseBodyAdvice<Object> {
+
+    // 해당 Advice 적용 범위
+    @Override
+    public boolean supports(MethodParameter returnType,
+        Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    // 응답 변환 매서드
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType,
+        MediaType selectedContentType,
+        Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request,
+        ServerHttpResponse response) {
+
+        // 만약 반환 타입이 void이면 data 없이 응답
+        if (Void.TYPE.equals(returnType.getParameterType())) {
+            return new ResultResponse("success", "처리가 완료되었습니다.", null);
+        }
+
+        // 만약 String이면 예외 발생
+        if (body instanceof String) {
+            throw new GlobalException(ErrorCode.NOT_ALLOW_STRING);
+        }
+
+        if(body instanceof ResultResponse){
+            return body;
+        }
+        return ResultResponse.success(body);
+    }
+}

--- a/src/main/java/spot/spot/global/controller/HealthCheckController.java
+++ b/src/main/java/spot/spot/global/controller/HealthCheckController.java
@@ -1,0 +1,78 @@
+package spot.spot.global.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import spot.spot.global.exception.ErrorCode;
+import spot.spot.global.exception.GlobalException;
+
+@RestController
+@RequestMapping("/health")
+public class HealthCheckController {
+
+    // ✅ 1️⃣ 기본형 반환 (int, double, boolean 등)
+    @GetMapping("/primitive")
+    public int getPrimitive() {
+        return 42; // 자동으로 ResultResponse.success(42)로 감싸져야 함
+    }
+
+    // ✅ 2️⃣ 참조형 반환 (String)
+    @GetMapping("/string")
+    public String getString() {
+        return "Spring Boot is running!";
+    }
+
+    // ✅ 3️⃣ DTO 객체 반환
+    @GetMapping("/dto")
+    public SampleDto getDto() {
+        return new SampleDto(1, "Test DTO");
+    }
+
+    // ✅ 4️⃣ List<T> 반환
+    @GetMapping("/list")
+    public List<String> getList() {
+        return List.of("Apple", "Banana", "Cherry");
+    }
+
+    // ✅ 5️⃣ Map<K, V> 반환
+    @GetMapping("/map")
+    public Map<String, Object> getMap() {
+        return Map.of("name", "John", "age", 30, "active", true);
+    }
+
+    // ✅ 6️⃣ 예외 발생 테스트 (정의된 예외)
+    @GetMapping("/exception")
+    public void throwGlobalException() {
+        throw new GlobalException(ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    // ✅ 7️⃣ 예기치 않은 예외 테스트 (ArithmeticException)
+    @GetMapping("/unexpected-error")
+    public void throwUnexpectedError() {
+        int result = 10 / 0; // ArithmeticException 발생
+    }
+
+    // ✅ 8️⃣ ResponseEntity<T> 직접 반환 (ResponseBodyAdvice가 적용되지 않아야 함)
+    @GetMapping("/response-entity")
+    public ResponseEntity<SampleDto> getResponseEntity() {
+        return ResponseEntity.ok(new SampleDto(2, "ResponseEntity 사용"));
+    }
+
+    // ✅ 9️⃣ POST 요청으로 DTO 테스트
+    @PostMapping("/post-dto")
+    public SampleDto postDto(@RequestBody SampleDto dto) {
+        return dto; // 공통 응답으로 감싸져야 함
+    }
+}
+
+// ✅ DTO 클래스
+@Data
+@AllArgsConstructor
+class SampleDto {
+    private int id;
+    private String name;
+}

--- a/src/main/java/spot/spot/global/dto/response/ResultResponse.java
+++ b/src/main/java/spot/spot/global/dto/response/ResultResponse.java
@@ -1,0 +1,22 @@
+package spot.spot.global.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class ResultResponse<T> {
+    private String status;
+    private String message;
+    private T data;
+
+    public static<T> ResultResponse<T> success (T data) {
+        return new ResultResponse<>("success", "정상적으로 처리하였습니다.", data);
+    }
+
+    public static <T> ResultResponse<T> fail (String message) {
+        return new ResultResponse<>("fail", message, null);
+    }
+}

--- a/src/main/java/spot/spot/global/exception/ErrorCode.java
+++ b/src/main/java/spot/spot/global/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package spot.spot.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 멤버가 존재하지 않습니다."),
+    NOT_ALLOW_STRING(HttpStatus.INTERNAL_SERVER_ERROR, "백엔드 담당자가 String으로 반환을 설정했습니다. String 반환은 허용되지 않습니다. 담당자에게 문의하세요!")
+    ;
+    private final HttpStatus status;
+    private final String message;
+    // global (공통)
+}

--- a/src/main/java/spot/spot/global/exception/GlobalException.java
+++ b/src/main/java/spot/spot/global/exception/GlobalException.java
@@ -1,0 +1,10 @@
+package spot.spot.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class GlobalException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public GlobalException(ErrorCode errorCode) { this.errorCode = errorCode; }
+}

--- a/src/main/java/spot/spot/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/spot/spot/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package spot.spot.global.exception;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import spot.spot.global.dto.response.ResultResponse;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+    private static final HttpHeaders jsonHeaders;
+
+    static {
+        jsonHeaders = new HttpHeaders();
+        jsonHeaders.add(HttpHeaders.CONTENT_TYPE, "application/json");
+    }
+    // 사용자가 예측 가능한 에러 발생 시
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ResultResponse<Object>> handleGlobalException ( GlobalException globalException) {
+        return ResponseEntity
+            .status(globalException.getErrorCode().getStatus())
+            .headers(jsonHeaders)
+            .body(ResultResponse.fail(globalException.getErrorCode().getMessage()));
+    }
+
+    // 예기치 못한 에러 발생 시 (일단 에러 내용이 front 한테도 보이게 뒀습니다. 배포할 때 고치겠습니다.
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResultResponse<Object>> handleUnExpectException (Exception e) {
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .headers(jsonHeaders)
+            .body(ResultResponse.fail("서버 내부 오류 발생: " + e.getMessage()));
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=spot
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+server:
+  port: 8080
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+    context-path: /api
+  tomcat:
+    threads:
+      max: 200
+    max-connections: 10000


### PR DESCRIPTION
# 💡 Issue
- #1 
# 🌱 Key changes
- [x] 공통 응답 로직을 작성하였습니다.
- [x] 팀원들이 따로 ResultResponse 객체를 감싸지 않아도, AOP Advice를 통해 자동으로 감싸지도록 후처리를 하였습니다.
- [x] 그냥 String 값만 반환 하는 것은 막아놨습니다. ( DTO 반환 유도 )
- [x] 에러는 각자가 각 도메인에서 필요로 하는 예외 타입을 만들 수 있도록 하였습니다.

# ✅ To Reviewers

로직 보시고, 가독성 잡을 부분이나, 이해 안되는 부분 가감 없이 말씀해 주세요!

# 📸 스크린샷
<img width="616" alt="image" src="https://github.com/user-attachments/assets/dce0ee0c-7e86-4834-9f8f-2622ea41f0e7" />

내부 오류는 원래 보이면 안되는데 개발하는 기간 동안만 API 반환값에 넣겠습니다.
<img width="611" alt="image" src="https://github.com/user-attachments/assets/1af08ae1-9fed-4e28-9f84-cdacff2da842" />
String의 경우 커스텀 예외로 막아두었습니다.
<img width="639" alt="image" src="https://github.com/user-attachments/assets/e94012bb-65eb-4d85-8a25-a3143920a92d" />

