### PR TITLE
chore: make Logging colorful

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,6 @@ dependencies {
 
 	// Logging ⭐
 	implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.16'
-	implementation 'com.squareup:javapoet:1.13.0'
-	annotationProcessor 'com.google.auto.service:auto-service:1.0'
-	compileOnly 'javax.annotation:javax.annotation-api:1.3.2' // Java 9 이상에서는 필요
 
 	// TEST 🚀
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/spot/spot/global/healthCheck/HealthCheckController.java
+++ b/src/main/java/spot/spot/global/healthCheck/HealthCheckController.java
@@ -2,6 +2,7 @@ package spot.spot.global.healthCheck;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -10,6 +11,7 @@ import java.util.Map;
 import spot.spot.global.response.format.ErrorCode;
 import spot.spot.global.response.format.GlobalException;
 
+@Slf4j
 @RestController
 @RequestMapping("/health")
 public class HealthCheckController {
@@ -17,6 +19,9 @@ public class HealthCheckController {
     // ✅ 1️⃣ 기본형 반환 (int, double, boolean 등)
     @GetMapping("/primitive")
     public int getPrimitive() {
+        log.info("TRACE LEVEL LOG");
+        log.warn(" WARN LEVEL LOG");
+        log.error("ERROR LEVEL LOG");
         return 42; // 자동으로 ResultResponse.success(42)로 감싸져야 함
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,14 @@ server:
     threads:
       max: 200
     max-connections: 10000
+    spring:
+      application:
+        name: spot
+      datasource:
+        url: jdbc:h2:mem:testdb
+        driver-class-name: org.h2.Driver
+        username: sa
+        password:
+      h2:
+        console:
+          enabled: true

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <property name="CONSOLE_LOG_PATTERN"
+    value="%d{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{36}) - %highlight(%msg) %n"/>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>


### PR DESCRIPTION
# 💡 Issue
- resolved #18

# 🌱 Key changes
- [x] 로그 5단계 별로 색깔 지정 했습니다.
- [x] **INFO는 Green으로 설정 했는데, 제 인텔리제이 스킨 떄문에 색깔이 다르게 나오는 거 같습니다.**

# ✅ To Reviewers
나중에 보고 싶은 로그는 log.warn( ) 이나 error.( ) 로 확인해보시면 될 것 같습니다. 

# 📸 스크린샷
<img width="796" alt="image" src="https://github.com/user-attachments/assets/98bfac91-e436-4b34-a84a-1171a20f4318" />

