### PR TITLE
chore: MapStruct 환경 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 compileJava {
 	options.compilerArgs += [
 			'--enable-preview',
-			'-Amapstruct.defaultComponentModel=spring' // here
+			'-Amapstruct.defaultComponentModel=spring' // @Mapper 어노테이션이 적힌 클래스는 자동으로 스프링 컨테이너에 등록
 	]
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-	// BASIC 🚀
+	// BASIC ⭐
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -40,7 +40,7 @@ dependencies {
 	annotationProcessor 'com.google.auto.service:auto-service:1.0'
 	compileOnly 'javax.annotation:javax.annotation-api:1.3.2' // Java 9 이상에서는 필요
 
-	// TEST 🚀
+	// TEST ⭐
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	runtimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -50,8 +50,25 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// SECURITY ⭐
+
+	// Map Struct ⭐
+	implementation group: 'org.mapstruct', name: 'mapstruct', version: '1.5.5.Final'			// MapStruct 사용을 위한 의존성 라이브러리
+	implementation group: 'org.mapstruct', name: 'mapstruct-processor', version: '1.5.5.Final'	// MapStruct는 컴파일 타임에 인터페이스의 구현체를 만들어서 build에 올림. 이를 위한 Processor 라이브러리
+	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'						// 컴파일 시간에 구현체를 만드는 Lombok과 컴파일 타임에 충돌이 날 수 있음. 따라서 순서 조정 (Lombok 먼저, MapStruct 다음에)
+}
+
+// Add VM Option (1)
+compileJava {
+	options.compilerArgs += [
+			'--enable-preview',
+			'-Amapstruct.defaultComponentModel=spring' // here
+	]
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+	jvmArgs([
+			'--enable-preview',
+			'-Amapstruct.defaultComponentModel=spring'
+	])
 }


### PR DESCRIPTION
# 💡 Issue
- resloved #21 

# 🌱 Key changes
- [x] MapStruct 의존성 추가
- [x] MapStruct 컴파일 타임에 Lombok가 충돌 나지 않도록 순서 조정 
- [x] MapStruct의 고유 어노테이션인 @ Mapper가 붙은 클래스는 컴파일 시 자동으로 해당 클래스의 객체가 스프링 컨테이너에 등록 되도록 (의존성 주입 지키기, 자동화)

# ✅ To Reviewers
**Map Struct**는 Entity -> DTO, DTO -> Entity를 Mapping 해주는 라이브러리 입니다. 
[사용법 참고](https://medium.com/naver-cloud-platform/%EA%B8%B0%EC%88%A0-%EC%BB%A8%ED%85%90%EC%B8%A0-%EB%AC%B8%EC%9E%90-%EC%95%8C%EB%A6%BC-%EB%B0%9C%EC%86%A1-%EC%84%9C%EB%B9%84%EC%8A%A4-sens%EC%9D%98-mapstruct-%EC%A0%81%EC%9A%A9%EA%B8%B0-8fd2bc2bc33b)

# 📸 스크린샷
