### PR TITLE
feat: vault key,value 값 반환 map 저장

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:spot;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:spot;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MYSQL
     username: sa
     password:
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   application:
     name: spot-be
   profiles:
-    active: local
+    active: local , key
   thymeleaf:
     check-template-location: false
   servlet:
@@ -55,11 +55,12 @@ klaytn:
         api:
           url: https://api.bithumb.com/v1/ticker?markets=KRW-KAIA
 
-valut:
+vault:
   connect:
-    url: https://infra.ilmatch.net/v1/be/
+    url: https://infra.ilmatch.net/v1/
 
+# key 값에 본인의 vault pat 토큰 값을 입력하셔야합니다.
 github:
   personal:
     pat:
-      key: root
+      key:


### PR DESCRIPTION
# 💡 Issue
- #50 
# 🌱 Key changes
- [x] 배포된 vault서버의 key,value값을 반환하여 map에 저장
- [x] application.yml에 github.personal.pat.key에 본인의 github pat토큰을 입력하고 실행해야함

# ✅ To Reviewers
사용법은 
GlobalVaultResponseKeys handler;

Map<String, String> vaultKeys = handler.getVaultKeys();

valutKeys.get("key값") 을 넣으시면 value가 반환됩니다.

# 📸 스크린샷
## application.yml

<img width="812" alt="스크린샷 2025-02-19 오후 1 43 38" src="https://github.com/user-attachments/assets/16e2abee-be98-48f2-b345-bdfa393a4e05" />

## vault 접근 토큰 반환

<img width="1049" alt="스크린샷 2025-02-19 오후 1 44 21" src="https://github.com/user-attachments/assets/5ed3b22b-eeab-4477-9ff0-349fbc135743" />

## valut key , value값 로그

<img width="723" alt="스크린샷 2025-02-19 오후 1 48 03" src="https://github.com/user-attachments/assets/4171f615-676f-413c-923d-897f512d0ff3" />
