### PR TITLE
feat: 카카오 간편 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,13 +39,17 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 
 	// BASIC ⭐
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+//	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
 	// SECURITY ⭐
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	// DB 📦
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/spot/spot/domain/member/OAuth2FailureHandler.java
+++ b/src/main/java/spot/spot/domain/member/OAuth2FailureHandler.java
@@ -1,0 +1,21 @@
+package spot.spot.domain.member;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        log.error("🔥 OAuth2 로그인 실패: {}", exception.getMessage());
+        response.sendRedirect("/login?error=" + exception.getMessage());
+    }
+}

--- a/src/main/java/spot/spot/domain/member/OAuthProvider.java
+++ b/src/main/java/spot/spot/domain/member/OAuthProvider.java
@@ -1,6 +1,0 @@
-package spot.spot.domain.member;
-
-public enum OAuthProvider {
-    //회원의 로그인 타입 저장
-    KAKAO,NAVER;
-}

--- a/src/main/java/spot/spot/domain/member/entity/Member.java
+++ b/src/main/java/spot/spot/domain/member/entity/Member.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import spot.spot.domain.job.entity.Matching;
+import spot.spot.domain.member.entity.dto.MemberRole;
 import spot.spot.domain.notification.entity.FcmToken;
 import spot.spot.domain.notification.entity.Notification;
 
@@ -36,6 +37,8 @@ public class Member {
 
     private int point;
 
+    private MemberRole memberRole;
+
     private LocalDateTime deletedAt; //삭제일자
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -46,18 +49,6 @@ public class Member {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FcmToken> fcmTokenList;
-
-    /*
-
-    private OAuthProvider oAuthProvider; //소셜로그인
-
-    public Member(String email,String nickname,OAuthProvider oAuthProvider){
-        this.email = email;
-        this.nickname = nickname;
-        this.oAuthProvider = oAuthProvider;
-    }
-
-     */
 
 }
 

--- a/src/main/java/spot/spot/domain/member/entity/OAuth2Member.java
+++ b/src/main/java/spot/spot/domain/member/entity/OAuth2Member.java
@@ -1,0 +1,39 @@
+package spot.spot.domain.member.entity;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class OAuth2Member implements OAuth2User {
+
+    private final Member member;
+
+    @Override
+    public <A> A getAttribute(String name) {
+        return OAuth2User.super.getAttribute(name);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Map.of();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getName() {
+        return member.getId().toString();
+    }
+
+    public String getNickName() {
+        return member.getNickname();
+    }
+}

--- a/src/main/java/spot/spot/domain/member/entity/dto/MemberRequest.java
+++ b/src/main/java/spot/spot/domain/member/entity/dto/MemberRequest.java
@@ -1,0 +1,18 @@
+package spot.spot.domain.member.entity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MemberRequest {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class register{
+        private String nickname;
+        private String email;
+    }
+}

--- a/src/main/java/spot/spot/domain/member/entity/dto/MemberRole.java
+++ b/src/main/java/spot/spot/domain/member/entity/dto/MemberRole.java
@@ -1,0 +1,5 @@
+package spot.spot.domain.member.entity.dto;
+
+public enum MemberRole {
+    MEMBER, ADMIN
+}

--- a/src/main/java/spot/spot/domain/member/entity/dto/OAuth2MemberResponse.java
+++ b/src/main/java/spot/spot/domain/member/entity/dto/OAuth2MemberResponse.java
@@ -1,0 +1,24 @@
+package spot.spot.domain.member.entity.dto;
+
+import java.util.Map;
+
+public class OAuth2MemberResponse {
+
+    private final Map<String, Object> properties;
+    private final Map<String, Object> kakaoAccount;
+
+    public OAuth2MemberResponse(Map<String, Object> attribute) {
+        this.properties = (Map<String, Object>) attribute.get("properties");
+        this.kakaoAccount = (Map<String, Object>) attribute.get("kakao_account");
+    }
+
+    public String getKakaoNickname() {
+        return properties.get("nickname").toString();
+    }
+
+    public String getKakaoProfileImage() {
+        return properties.get("profile_image").toString();
+    }
+
+    public String getKakaoEmail(){ return kakaoAccount.get("email").toString();}
+}

--- a/src/main/java/spot/spot/domain/member/entity/jwt/JwtFilter.java
+++ b/src/main/java/spot/spot/domain/member/entity/jwt/JwtFilter.java
@@ -1,0 +1,89 @@
+package spot.spot.domain.member.entity.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import spot.spot.domain.member.entity.OAuth2Member;
+import spot.spot.domain.member.service.TokenService;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final TokenService tokenService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader("Authorization");
+        String token = null;
+
+        if(authorizationHeader != null && authorizationHeader.startsWith("Bearer ")){
+            token = authorizationHeader.substring(7);
+        }
+        if (token != null) {
+            //토큰없는상태 첫 로그인
+            if (SecurityContextHolder.getContext().getAuthentication() == null) {
+                authenticateToken(token,response);
+            }else{
+                if (jwtUtil.isExpired(token)) {
+                    handleExpiredToken(token, request, response);
+                }
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void authenticateToken(String token, HttpServletResponse response) {
+        if (!jwtUtil.isExpired(token)) {
+            Authentication authentication = jwtUtil.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            log.info("AccessToken 만료됨");
+            // AccessToken 만료 시 처리 로직 추가 가능
+            Token token1 = tokenService.findToken(token);
+            String loginId = jwtUtil.getLoginId(token1.getRefreshToken());
+            if(!jwtUtil.isExpired(token1.getRefreshToken())){
+                log.info("AccessToken 재발급됨");
+                String newAccessToken = jwtUtil.getAccessToken((OAuth2Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+                token1.setAccessToken(newAccessToken);
+                tokenService.saveToken(token1);
+                response.setHeader("Authorization", "Bearer " + newAccessToken);
+                SecurityContextHolder.getContext().setAuthentication(jwtUtil.getAuthentication(newAccessToken));
+            }else {
+                tokenService.deleteToken(loginId);
+            }
+        }
+    }
+
+    private void handleExpiredToken(String token, HttpServletRequest request, HttpServletResponse response) {
+        Token redisToken = tokenService.findToken(token);
+        String loginId = jwtUtil.getLoginId(redisToken.getRefreshToken());
+
+        if (redisToken != null && jwtUtil.isExpired(redisToken.getRefreshToken())) {
+            // RefreshToken도 만료된 경우
+            log.info("RefreshToken 만료");
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);  // 403 Forbidden 응답
+        } else if (redisToken != null) {
+            // RefreshToken이 유효한 경우 AccessToken 재발급
+            log.info("RefreshToken 유효");
+            String newAccessToken = jwtUtil.getAccessToken((OAuth2Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+            redisToken.setAccessToken(newAccessToken);
+            tokenService.saveToken(redisToken);
+            response.setHeader("Authorization", "Bearer " + newAccessToken);
+            SecurityContextHolder.getContext().setAuthentication(jwtUtil.getAuthentication(newAccessToken));
+        } else {
+            tokenService.deleteToken(loginId);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);  // 403 Forbidden 응답
+        }
+    }
+}

--- a/src/main/java/spot/spot/domain/member/entity/jwt/JwtFilter.java
+++ b/src/main/java/spot/spot/domain/member/entity/jwt/JwtFilter.java
@@ -33,7 +33,7 @@ public class JwtFilter extends OncePerRequestFilter {
         if(authorizationHeader != null && authorizationHeader.startsWith("Bearer ")){
             token = authorizationHeader.substring(7);
         }
-        if (!token.isEmpty()) {
+        if (token != null) {
             if (SecurityContextHolder.getContext().getAuthentication() == null) {
                 authenticateToken(token,response);
             }else{

--- a/src/main/java/spot/spot/domain/member/entity/jwt/JwtUtil.java
+++ b/src/main/java/spot/spot/domain/member/entity/jwt/JwtUtil.java
@@ -1,0 +1,102 @@
+package spot.spot.domain.member.entity.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import spot.spot.domain.member.entity.Member;
+import spot.spot.domain.member.entity.OAuth2Member;
+import spot.spot.domain.member.service.MemberService;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final MemberService memberService;
+
+    @Value("${spring.jwt.access.token}")
+    private long ACCESS_TOKEN_EXPIRE_TIME;
+
+    @Value("${spring.jwt.refresh.token}")
+    private long REFRESH_TOKEN_EXPIRE_TIME;
+
+    public JwtUtil(@Value("${spring.jwt.secretKey}") String secretKey, MemberService memberService) {
+        this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey));
+        this.memberService =memberService;
+    }
+
+    //token생성
+    public String createToken(OAuth2Member oAuth2Member, long expireTime){
+        return Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setSubject(oAuth2Member.getName())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expireTime))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    //accessToken생성
+    public String getAccessToken(OAuth2Member oAuth2Member){
+        return createToken(oAuth2Member, ACCESS_TOKEN_EXPIRE_TIME);
+    }
+
+    //refreshToken생성
+    public String getRefreshToken(OAuth2Member oAuth2Member) {
+        return createToken(oAuth2Member, REFRESH_TOKEN_EXPIRE_TIME);
+    }
+
+    //token으로 유저 loginId조회
+    public String getLoginId(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.getSubject();
+    }
+
+    //인증 객체 생성
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        // ✅ JWT의 subject를 Long 타입의 member ID로 변환하여 사용자 조회
+        Long memberId = Long.parseLong(claims.getSubject());
+        Member findMember = memberService.findById(memberId);
+        if (findMember == null) {
+            throw new UsernameNotFoundException("일치하는 유저가 없습니다.");
+        }
+
+        OAuth2Member userDetails = new OAuth2Member(findMember);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    //유효한 토큰인지 확인
+    public Boolean isExpired(String token) {
+        try{
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            return claims.getExpiration().before(new Date());
+        } catch (Exception e){
+            return true;
+        }
+    }
+}
+

--- a/src/main/java/spot/spot/domain/member/entity/jwt/Token.java
+++ b/src/main/java/spot/spot/domain/member/entity/jwt/Token.java
@@ -1,0 +1,26 @@
+package spot.spot.domain.member.entity.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@AllArgsConstructor
+@Getter
+@Builder
+@RedisHash(value = "userToken", timeToLive = 86400)
+public class Token {
+
+    @Id
+    private String refreshToken;
+
+    @Indexed
+    @Setter
+    private String accessToken;
+
+    @Indexed
+    private String memberId;
+}

--- a/src/main/java/spot/spot/domain/member/entity/jwt/Token.java
+++ b/src/main/java/spot/spot/domain/member/entity/jwt/Token.java
@@ -1,14 +1,12 @@
 package spot.spot.domain.member.entity.jwt;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @Builder
 @RedisHash(value = "userToken", timeToLive = 86400)

--- a/src/main/java/spot/spot/domain/member/repository/MemberRepository.java
+++ b/src/main/java/spot/spot/domain/member/repository/MemberRepository.java
@@ -4,6 +4,10 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import spot.spot.domain.member.entity.Member;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsById(@NotNull Long id);
+
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/spot/spot/domain/member/service/MemberService.java
+++ b/src/main/java/spot/spot/domain/member/service/MemberService.java
@@ -1,0 +1,50 @@
+package spot.spot.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import spot.spot.domain.member.entity.Member;
+import spot.spot.domain.member.entity.dto.MemberRequest;
+import spot.spot.domain.member.entity.dto.MemberRole;
+import spot.spot.domain.member.repository.MemberRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void register(MemberRequest.register register) {
+
+        Member member = Member.builder()
+                .nickname(register.getNickname())
+                .email(register.getEmail())
+                .point(0)
+                .memberRole(MemberRole.MEMBER)
+                .build();
+
+        memberRepository.save(member);
+    }
+
+    @Transactional
+    public Member findByNickname(String nickname) {
+        Optional<Member> findMember = memberRepository.findByNickname(nickname);
+        if(findMember.isEmpty()) return null;
+
+        return findMember.get();
+    }
+
+    @Transactional
+    public Member findById(Long id) {
+        Optional<Member> findMember = memberRepository.findById(id);
+        if(findMember.isEmpty()) return null;
+
+        return findMember.get();
+    }
+}

--- a/src/main/java/spot/spot/domain/member/service/OAuth2FailureHandler.java
+++ b/src/main/java/spot/spot/domain/member/service/OAuth2FailureHandler.java
@@ -1,4 +1,4 @@
-package spot.spot.domain.member;
+package spot.spot.domain.member.service;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/spot/spot/domain/member/service/OAuth2MemberService.java
+++ b/src/main/java/spot/spot/domain/member/service/OAuth2MemberService.java
@@ -1,0 +1,68 @@
+package spot.spot.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import spot.spot.domain.member.entity.Member;
+import spot.spot.domain.member.entity.OAuth2Member;
+import spot.spot.domain.member.entity.dto.MemberRequest;
+import spot.spot.domain.member.entity.dto.OAuth2MemberResponse;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2MemberService extends DefaultOAuth2UserService {
+
+    private final MemberService memberService;
+
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        log.info("oAuth2user : {}", oAuth2User);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2MemberResponse oAuth2MemberResponse = new OAuth2MemberResponse(oAuth2User.getAttributes());
+
+        MemberRequest.register userInfo = extractUserInfo(registrationId, oAuth2MemberResponse);
+
+        return registerOrFindUser(userInfo);
+    }
+
+    private MemberRequest.register extractUserInfo(String registrationId, OAuth2MemberResponse oAuth2MemberResponse) {
+        String nickname = "";
+        String email = "";
+        log.info("registrationId : {}", registrationId);
+
+        switch (registrationId) {
+            case "kakao":
+                nickname = oAuth2MemberResponse.getKakaoNickname();
+                email = oAuth2MemberResponse.getKakaoEmail();
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported registrationId: " + registrationId);
+        }
+
+        return MemberRequest.register.builder()
+                .email(email)
+                .nickname(nickname)
+                .build();
+    }
+
+    private OAuth2User registerOrFindUser(MemberRequest.register userInfo) {
+        Member existMember = memberService.findByNickname(userInfo.getNickname());
+
+        if (existMember == null) {
+            log.info("registerOrFindUser firstLogin");
+            memberService.register(userInfo);
+            Member newMember = memberService.findByNickname(userInfo.getNickname());
+            return new OAuth2Member(newMember);
+        }
+        log.info("registerOrFindUser notFirstLogin");
+        return new OAuth2Member(existMember);
+    }
+}

--- a/src/main/java/spot/spot/domain/member/service/OAuth2SuccessHandler.java
+++ b/src/main/java/spot/spot/domain/member/service/OAuth2SuccessHandler.java
@@ -1,0 +1,47 @@
+package spot.spot.domain.member.service;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import spot.spot.domain.member.entity.OAuth2Member;
+import spot.spot.domain.member.entity.jwt.JwtUtil;
+import spot.spot.domain.member.entity.jwt.Token;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+    private final TokenService tokenService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2Member oAuth2Member = (OAuth2Member) authentication.getPrincipal();
+
+        String memberId = oAuth2Member.getName();
+        String nickname = oAuth2Member.getNickName();
+
+        String accessToken = jwtUtil.getAccessToken(oAuth2Member);
+        String refreshToken = jwtUtil.getRefreshToken(oAuth2Member);
+        Token token = Token.builder().accessToken(accessToken).refreshToken(refreshToken).memberId(memberId).build();
+        tokenService.saveToken(token);
+
+        String encodedNickname = nickname.matches("^[a-zA-Z0-9]*$") ? nickname : URLEncoder.encode(nickname, "UTF-8");
+
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(oAuth2Member, null, oAuth2Member.getAuthorities());
+        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        response.sendRedirect("https://ilmatch.net/oauth2/redirect?accessToken=" + accessToken + "&nickname=" + encodedNickname);
+    }
+}

--- a/src/main/java/spot/spot/domain/member/service/TokenService.java
+++ b/src/main/java/spot/spot/domain/member/service/TokenService.java
@@ -1,0 +1,47 @@
+package spot.spot.domain.member.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import spot.spot.domain.member.entity.jwt.Token;
+
+import java.util.LinkedHashMap;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final RedisTemplate<String, Token> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private static final String TOKEN_PREFIX = "token:";
+
+    public void saveToken(Token token) {
+        String key = TOKEN_PREFIX + token.getAccessToken();
+        redisTemplate.opsForValue().set(key, token);
+    }
+
+    public Token findToken(String accessToken){
+        String key = TOKEN_PREFIX + accessToken;
+        Object tokenData = redisTemplate.opsForValue().get(key);
+
+        if(tokenData instanceof LinkedHashMap){
+            return objectMapper.convertValue(tokenData, Token.class);
+        }
+        return (Token) tokenData;
+    }
+
+    public void deleteToken(String accessToken) {
+        String key = TOKEN_PREFIX + accessToken;
+        redisTemplate.delete(key);
+    }
+
+    public void updateAccessToken(String accessToken, String newAccessToken) {
+        String key = TOKEN_PREFIX + accessToken;
+        Token token = (Token) redisTemplate.opsForValue().get(key);
+        if (token != null) {
+            token.setAccessToken(newAccessToken);
+            redisTemplate.opsForValue().set(key, token);
+        }
+    }
+}

--- a/src/main/java/spot/spot/domain/member/service/TokenService.java
+++ b/src/main/java/spot/spot/domain/member/service/TokenService.java
@@ -2,6 +2,7 @@ package spot.spot.domain.member.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import spot.spot.domain.member.entity.jwt.Token;
@@ -10,6 +11,7 @@ import java.util.LinkedHashMap;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TokenService {
 
     private final RedisTemplate<String, Token> redisTemplate;
@@ -38,10 +40,18 @@ public class TokenService {
 
     public void updateAccessToken(String accessToken, String newAccessToken) {
         String key = TOKEN_PREFIX + accessToken;
-        Token token = (Token) redisTemplate.opsForValue().get(key);
+        Token token = redisTemplate.opsForValue().get(key);
         if (token != null) {
-            token.setAccessToken(newAccessToken);
-            redisTemplate.opsForValue().set(key, token);
+            log.info("updateAccessToken = {}", newAccessToken);
+            Token updatedToken = Token.builder()
+                    .accessToken(newAccessToken)
+                    .refreshToken(token.getRefreshToken())
+                    .memberId(token.getMemberId())
+                    .build();
+
+            redisTemplate.delete(key);
+            String newKey = TOKEN_PREFIX + newAccessToken;
+            redisTemplate.opsForValue().set(newKey, updatedToken);
         }
     }
 }

--- a/src/main/java/spot/spot/global/config/SecurityConfig.java
+++ b/src/main/java/spot/spot/global/config/SecurityConfig.java
@@ -6,28 +6,46 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import spot.spot.domain.member.OAuth2FailureHandler;
+import spot.spot.domain.member.entity.jwt.JwtFilter;
+import spot.spot.domain.member.entity.jwt.JwtUtil;
+import spot.spot.domain.member.service.OAuth2MemberService;
+import spot.spot.domain.member.service.OAuth2SuccessHandler;
+import spot.spot.domain.member.service.TokenService;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-
+    private final JwtUtil jwtUtil;
+    private final TokenService tokenService;
+    private final OAuth2MemberService oAuth2MemberService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
     /*
      *  Security Config의 변수 설명 - 필요한 것
      *  (1) JwtUtil                  : Jwt 토큰 발급, 검증 등의 로직 담당
      *  (2) AuthenticationEntryPoint : 인증 실패 시 예외 처리
      *  (3) AccessDeniedHandler      : 해당 경로를 요청할 권한이 없을 때 예외 처리
      */
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
 
     private final String[] whiteList = {
         "/ws-stomp/**", // * 웹 소켓 연결 및 테스팅이 완료되면 삭제
@@ -81,10 +99,15 @@ public class SecurityConfig {
                     auth                                        // (8)
                         .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()   // 비동기 접근 열어주기
                         .dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll() // FORWARD REDIRECTING 열어주기
-                        .requestMatchers("/api/**").permitAll()
+                        .requestMatchers("/api/**", "/api/member/login/kakao", "/login/oauth2/code/kakao").permitAll()
                         .requestMatchers(whiteList).permitAll()
-                        .anyRequest().permitAll()
-            );
+                        .anyRequest().permitAll())
+                .oauth2Login(login -> login
+                        .authorizationEndpoint(endpoint -> endpoint.baseUri("/api/member/login"))
+                        .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userService(oAuth2MemberService))
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler))
+                .addFilterBefore(new JwtFilter(jwtUtil, tokenService), UsernamePasswordAuthenticationFilter.class);;
         return http.build();
     }
 

--- a/src/main/java/spot/spot/global/config/SwaggerConfig.java
+++ b/src/main/java/spot/spot/global/config/SwaggerConfig.java
@@ -49,7 +49,7 @@ public class SwaggerConfig {
             .addSecurityItem(addSecurityItem)
             .addServersItem(new Server().url("https://ilmatch.net/api")
                 .description("Default Server URL"))
-            .addServersItem(new Server().url("http://localhost:8080/api")
+            .addServersItem(new Server().url("http://localhost:8080")
                 .description("Local Development Server"))
             .info(info)
             .components(components)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   application:
     name: spot-be
   profiles:
-    active: local
+    active: local, key
   thymeleaf:
     check-template-location: false
   servlet:
@@ -19,7 +19,7 @@ server:
       charset: UTF-8
       enabled: true
       force: true
-    context-path: /api
+    context-path: /
   tomcat:
     threads:
       max: 200
@@ -32,13 +32,14 @@ springdoc:
     path: /v3/api-docs
   swagger-ui:
     enabled: true
+    path: /swagger-ui.html
     tags-sorter: alpha            # alpha: 알파벳 순 태그 정렬, method: HTTP Method 순 정렬
     operations-sorter: alpha      # alpha: 알파벳 순 태그 정렬, method: HTTP Method 순 정렬
     display-request-duration: true
     disable-swagger-default-url: true # petStore default로 들어가는 것 끄기
     urls:
       - name: "Default Server URL"
-        url: "/api/v3/api-docs"
+        url: "/v3/api-docs"
 
   default-produces-media-type: application/json
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,7 +32,7 @@ springdoc:
     path: /v3/api-docs
   swagger-ui:
     enabled: true
-    path: /swagger-ui.html
+    path: /api/swagger-ui.html
     tags-sorter: alpha            # alpha: 알파벳 순 태그 정렬, method: HTTP Method 순 정렬
     operations-sorter: alpha      # alpha: 알파벳 순 태그 정렬, method: HTTP Method 순 정렬
     display-request-duration: true


### PR DESCRIPTION
# 💡 Issue
- #32 
# 🌱 Key changes
- [x] 카카오 로그인 구현
- [x] accessToken, refreshToken jwt토큰으로 발급
- [x] 발급된 토큰 redis에 저장 TTL - 86400
- [x] swagger 접속 url 변경

# ✅ To Reviewers
- 단순히 카카오 로그인과 jwt토큰을 redis에 저장하는 로직만 있습니다. 추후에 로그인 유저 데이터 변경이나, 중복 로그인 토큰 처리는 추가할 예정입니다.
- swagger 접속 url 앞단에 /api 추가했습니다.
# 📸 스크린샷
