### PR TITLE
refactor: dev 디비 엔터티 생성방식 변경

### DIFF
--- a/src/main/java/spot/spot/domain/member/entity/Member.java
+++ b/src/main/java/spot/spot/domain/member/entity/Member.java
@@ -23,19 +23,23 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     private String email;
 
+    @Setter
     private String nickname;
 
+    @Setter
     private String img;
 
+    @Setter
     private String phone;
 
+    @Setter
     private double lat; //위도
 
+    @Setter
     private double lng; //경도
-
-    private String account;
 
     @Setter
     private int point;

--- a/src/main/java/spot/spot/domain/member/entity/dto/MemberRequest.java
+++ b/src/main/java/spot/spot/domain/member/entity/dto/MemberRequest.java
@@ -14,5 +14,6 @@ public class MemberRequest {
     public static class register{
         private String nickname;
         private String email;
+        private String img;
     }
 }

--- a/src/main/java/spot/spot/domain/member/service/OAuth2MemberService.java
+++ b/src/main/java/spot/spot/domain/member/service/OAuth2MemberService.java
@@ -36,12 +36,14 @@ public class OAuth2MemberService extends DefaultOAuth2UserService {
     private MemberRequest.register extractUserInfo(String registrationId, OAuth2MemberResponse oAuth2MemberResponse) {
         String nickname = "";
         String email = "";
+        String img = "";
         log.info("registrationId : {}", registrationId);
 
         switch (registrationId) {
             case "kakao":
                 nickname = oAuth2MemberResponse.getKakaoNickname();
                 email = oAuth2MemberResponse.getKakaoEmail();
+                img = oAuth2MemberResponse.getKakaoProfileImage();
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported registrationId: " + registrationId);
@@ -50,6 +52,7 @@ public class OAuth2MemberService extends DefaultOAuth2UserService {
         return MemberRequest.register.builder()
                 .email(email)
                 .nickname(nickname)
+                .img(img)
                 .build();
     }
 

--- a/src/main/java/spot/spot/global/config/TestDataInitializerConfig.java
+++ b/src/main/java/spot/spot/global/config/TestDataInitializerConfig.java
@@ -24,7 +24,6 @@ public class TestDataInitializerConfig {
                     .nickname("테스트유저")
                     .lat(37.5665)
                     .lng(126.9780)
-                    .account("testAccount")
                     .point(100)
                     .deletedAt(null)
                     .build();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,8 +6,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-      naming:
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: true
     database: mysql
     properties:


### PR DESCRIPTION
# 💡 Issue

# 🌱 Key changes
- [x] 카카오 로그인 시 유저 프로필 이미지 추가 저장
- [x] dev 디비 테이블 생성방식 변경

# ✅ To Reviewers
디비 테이블 생성 방식을 카멜케이스에서 스네이크케이스 방식으로 변경하였습니다.
# 📸 스크린샷
<img width="171" alt="스크린샷 2025-02-21 오후 5 27 54" src="https://github.com/user-attachments/assets/c6b96e8e-159e-4c63-b068-93692d5cef80" />
