### PR TITLE
FEAT: 의뢰인이 마음에 드는 해결사에게 일을 의뢰하기 API + 의뢰할 시 해결사에게 FCM 알림 보내기

### DIFF
--- a/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
-import spot.spot.domain.job.dto.request.Worker2JobRequest;
+import spot.spot.domain.job.dto.request.Job4WorkerRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 
@@ -157,7 +157,7 @@ public interface Job4ClientDocs {
         })
     @PostMapping
     public void askJob2Worker (
-        @RequestBody Worker2JobRequest request
+        @RequestBody Job4WorkerRequest request
     );
 
 

--- a/src/main/java/spot/spot/domain/job/_docs/Job4WorkerDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4WorkerDocs.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-import spot.spot.domain.job.dto.request.Client2JobRequest;
+import spot.spot.domain.job.dto.request.Job4ClientRequest;
 import spot.spot.domain.job.dto.request.RegisterWorkerRequest;
 import spot.spot.domain.job.dto.response.NearByJobResponse;
 
@@ -129,10 +129,10 @@ public interface Job4WorkerDocs {
 
 
     @PostMapping
-    public void ask2ClientAboutGettingAnewJob(@RequestBody Client2JobRequest request);
+    public void askingJob2Client(@RequestBody Job4ClientRequest request);
 
     @PostMapping
-    public void startJob(@RequestBody Client2JobRequest request);
+    public void startJob(@RequestBody Job4ClientRequest request);
 
 
 

--- a/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
@@ -1,11 +1,13 @@
 package spot.spot.domain.job.controller;
 
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import spot.spot.domain.job._docs.Job4ClientDocs;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
-import spot.spot.domain.job.dto.request.Worker2JobRequest;
+import spot.spot.domain.job.dto.request.Job4WorkerRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.job.service.Job4ClientService;
@@ -48,9 +50,8 @@ public class Job4ClientController implements Job4ClientDocs {
         return job4ClientService.findJobAttenderList(id, pageable);
     }
 
-    @Override
-    public void askJob2Worker(Worker2JobRequest request) {
-
+    @PostMapping("/choice")
+    public void askJob2Worker(@RequestBody  Job4WorkerRequest request) {
+        job4ClientService.askingJob2Worker(request);
     }
-
 }

--- a/src/main/java/spot/spot/domain/job/controller/Job4WorkerController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4WorkerController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import spot.spot.domain.job._docs.Job4WorkerDocs;
-import spot.spot.domain.job.dto.request.Client2JobRequest;
+import spot.spot.domain.job.dto.request.Job4ClientRequest;
 import spot.spot.domain.job.dto.request.RegisterWorkerRequest;
 import spot.spot.domain.job.dto.response.NearByJobResponse;
 import spot.spot.domain.job.service.Job4WorkerService;
@@ -44,12 +44,12 @@ public class Job4WorkerController implements Job4WorkerDocs {
     }
 
     @PostMapping("/request")
-    public void ask2ClientAboutGettingAnewJob(@RequestBody Client2JobRequest request) {
-        job4WorkerService.askingJob(request);
+    public void askingJob2Client(@RequestBody Job4ClientRequest request) {
+        job4WorkerService.askingJob2Client(request);
     }
 
     @PostMapping("/start")
-    public void startJob(@RequestBody Client2JobRequest request) {
+    public void startJob(@RequestBody Job4ClientRequest request) {
         job4WorkerService.startJob(request);
     }
 

--- a/src/main/java/spot/spot/domain/job/dto/request/Job4ClientRequest.java
+++ b/src/main/java/spot/spot/domain/job/dto/request/Job4ClientRequest.java
@@ -2,7 +2,7 @@ package spot.spot.domain.job.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record Client2JobRequest(
+public record Job4ClientRequest(
     @Schema(description = "해결사가 맡아서 하고 싶은 일의 아이디")
     long jobId)
 { }

--- a/src/main/java/spot/spot/domain/job/dto/request/Job4WorkerRequest.java
+++ b/src/main/java/spot/spot/domain/job/dto/request/Job4WorkerRequest.java
@@ -6,7 +6,7 @@ public record Job4WorkerRequest(
     @Schema(description = "해결사가 맡으면 하는 일의 아이디")
     long jobId,
     @Schema(description = "해결사 dkdlel")
-    long attendeId
+    long attenderId
 ) {
 
 }

--- a/src/main/java/spot/spot/domain/job/dto/request/Job4WorkerRequest.java
+++ b/src/main/java/spot/spot/domain/job/dto/request/Job4WorkerRequest.java
@@ -2,7 +2,7 @@ package spot.spot.domain.job.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record Worker2JobRequest(
+public record Job4WorkerRequest(
     @Schema(description = "해결사가 맡으면 하는 일의 아이디")
     long jobId,
     @Schema(description = "해결사 dkdlel")

--- a/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
@@ -76,9 +76,9 @@ public class Job4ClientService {
 
     public void askingJob2Worker (Job4WorkerRequest request) {
         Member worker = memberRepository
-            .findById(request.attendeId()).orElseThrow(() -> new GlobalException(
+            .findById(request.attenderId()).orElseThrow(() -> new GlobalException(
             ErrorCode.MEMBER_NOT_FOUND));
-        Job job = changeJobStatusDsl.findJobWithValidation(request.attendeId(), request.jobId());
+        Job job = changeJobStatusDsl.findJobWithValidation(request.attenderId(), request.jobId());
         Matching matching = Matching.builder().job(job).member(worker).status(MatchingStatus.ATTENDER).build();
         matchingRepository.save(matching);
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("일 해결 신청 알림!").body(

--- a/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import spot.spot.domain.job.dto.request.Job4WorkerRequest;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
@@ -15,6 +16,7 @@ import spot.spot.domain.job.entity.Job;
 import spot.spot.domain.job.entity.Matching;
 import spot.spot.domain.job.entity.MatchingStatus;
 import spot.spot.domain.job.mapper.Job4ClientMapper;
+import spot.spot.domain.job.repository.dsl.ChangeJobStatusDsl;
 import spot.spot.domain.job.repository.dsl.SearchingListDsl;
 import spot.spot.domain.job.repository.jpa.JobRepository;
 import spot.spot.domain.job.repository.jpa.MatchingRepository;
@@ -22,6 +24,10 @@ import spot.spot.domain.member.entity.Member;
 import spot.spot.domain.member.entity.Worker;
 import spot.spot.domain.member.mapper.MemberMapper;
 import spot.spot.domain.member.repository.MemberRepository;
+import spot.spot.domain.notification.dto.response.FcmDTO;
+import spot.spot.domain.notification.service.FcmUtil;
+import spot.spot.global.response.format.ErrorCode;
+import spot.spot.global.response.format.GlobalException;
 import spot.spot.global.security.util.UserAccessUtil;
 import spot.spot.global.util.AwsS3ObjectStorage;
 
@@ -41,6 +47,8 @@ public class Job4ClientService {
     private final MemberRepository memberRepository;
     // query dsl
     private final SearchingListDsl searchingListDsl;
+    private final ChangeJobStatusDsl changeJobStatusDsl;
+    private final FcmUtil fcmUtil;
 
     public void registerJob(RegisterJobRequest request, MultipartFile file) {
         String url = awsS3ObjectStorage.uploadFile(file);
@@ -64,5 +72,16 @@ public class Job4ClientService {
         Slice<Worker> workers = searchingListDsl.findWorkersByJobIdAndStatus(jobId, pageable);
         List<AttenderResponse> responseList = job4ClientMapper.toResponseList(workers.getContent());
         return new SliceImpl<>(responseList, pageable, workers.hasNext());
+    }
+
+    public void askingJob2Worker (Job4WorkerRequest request) {
+        Member worker = memberRepository
+            .findById(request.attendeId()).orElseThrow(() -> new GlobalException(
+            ErrorCode.MEMBER_NOT_FOUND));
+        Job job = changeJobStatusDsl.findJobWithValidation(request.attendeId(), request.jobId());
+        Matching matching = Matching.builder().job(job).member(worker).status(MatchingStatus.ATTENDER).build();
+        matchingRepository.save(matching);
+        fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("일 해결 신청 알림!").body(
+            fcmUtil.askRequest2WorkerMsg(worker.getNickname(), job.getTitle())).build());
     }
 }

--- a/src/main/java/spot/spot/domain/job/service/Job4WorkerService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4WorkerService.java
@@ -1,13 +1,12 @@
 package spot.spot.domain.job.service;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import spot.spot.domain.job.dto.request.Client2JobRequest;
+import spot.spot.domain.job.dto.request.Job4ClientRequest;
 import spot.spot.domain.job.dto.request.RegisterWorkerRequest;
 import spot.spot.domain.job.dto.response.NearByJobResponse;
 import spot.spot.domain.job.entity.Job;
@@ -81,20 +80,20 @@ public class Job4WorkerService {
                 jobRepository.findById(jobId).orElseThrow(() -> new GlobalException(ErrorCode.JOB_NOT_FOUND)));
     }
     // 일 신청하기
-    public void askingJob (Client2JobRequest request) {
+    public void askingJob2Client(Job4ClientRequest request) {
         Member worker = userAccessUtil.getMember();
         Job job = changeJobStatusDsl.findJobWithValidation(worker.getId(), request.jobId());
         Matching matching = Matching.builder().job(job).member(worker).status(MatchingStatus.ATTENDER).build();
         matchingRepository.save(matching);
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("일 해결 신청 알림!").body(
-            fcmUtil.makeRequestingJobBody(worker.getNickname(), job.getTitle())).build());
+            fcmUtil.askRequest2ClientMsg(worker.getNickname(), job.getTitle())).build());
     }
     // 일 시작하기
-    public void startJob (Client2JobRequest request) {
+    public void startJob (Job4ClientRequest request) {
         Member worker = userAccessUtil.getMember();
         Job job = changeJobStatusDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.YES);
         changeJobStatusDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.START);
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("일 시작 알림!").body(
-            fcmUtil.makeStartingJobBody(worker.getNickname(), job.getTitle())).build());
+            fcmUtil.getStartedJobMsg(worker.getNickname(), job.getTitle())).build());
     }
 }

--- a/src/main/java/spot/spot/domain/notification/service/FcmUtil.java
+++ b/src/main/java/spot/spot/domain/notification/service/FcmUtil.java
@@ -9,13 +9,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.PlatformTransactionManager;
 import spot.spot.domain.member.entity.Member;
 import spot.spot.domain.notification.dto.response.FcmDTO;
 import spot.spot.domain.notification.entity.FcmToken;
 import spot.spot.domain.notification.repository.FcmTokenRepository;
 import spot.spot.global.logging.ColorLogger;
-import spot.spot.global.response.format.ErrorCode;
 
 @Slf4j
 @Component
@@ -71,11 +69,15 @@ public class FcmUtil  {
             .build();
     }
 
-    public String makeRequestingJobBody(String attenderName, String jobName){
+    public String askRequest2ClientMsg(String attenderName, String jobName){
         return attenderName + "님이 " + jobName + "을 해결하길 원합니다!";
     }
 
-    public String makeStartingJobBody(String attenderName, String jobName){
+    public String askRequest2WorkerMsg(String workerName, String jobName) {
+        return workerName + "님! " + jobName + "을 해결해 주십쇼!";
+    }
+
+    public String getStartedJobMsg(String attenderName, String jobName){
         return attenderName + "님이 " + jobName + "을 시작합니다!";
     }
 


### PR DESCRIPTION
# 💡 Issue

- resolve #86 

# 🌱 Key changes
- [ ] 요청의 유효성 검증 로직과 업데이트 로직을 모듈화하여서, 요청만 다르지, worker의 일 신청하기와 서비스 레이어부터는 로직이 같습니다.

# ✅ To Reviewers

다음으로 출발~

# 📸 스크린샷
![image](https://github.com/user-attachments/assets/98e1d46c-19e4-4aa0-823e-7e0db9b723b6)
![image](https://github.com/user-attachments/assets/c7ac32cf-14bd-450c-a4a6-8eb89c9cf812)


