### PR TITLE
FEAT: 의뢰자 입장에서 해결사가 잠수 탄 것 같을 때, 위탁 철회 요청을 보내는 API 구현 완료 

### DIFF
--- a/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.request.Job4WorkerRequest;
+import spot.spot.domain.job.dto.request.YesOrNoOfClientRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 
@@ -173,7 +174,7 @@ public interface Job4ClientDocs {
         })
     @PostMapping
     public void acceptJobRequestOfWorker (
-        @RequestBody Job4WorkerRequest request
+        @RequestBody YesOrNoOfClientRequest request
     );
 
 

--- a/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
@@ -15,8 +15,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
+import spot.spot.domain.job.dto.request.Job2WorkerRequest;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
-import spot.spot.domain.job.dto.request.Job4WorkerRequest;
+import spot.spot.domain.job.dto.request.Job2ClientRequest;
 import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
@@ -158,7 +159,7 @@ public interface Job4ClientDocs {
         })
     @PostMapping
     public void askJob2Worker (
-        @RequestBody Job4WorkerRequest request
+        @RequestBody Job2ClientRequest request
     );
 
     @Operation(summary = "너 일해라",
@@ -175,6 +176,12 @@ public interface Job4ClientDocs {
     @PostMapping
     public void acceptJobRequestOfWorker (
         @RequestBody YesOrNo2WorkersRequest request
+    );
+
+
+    @PostMapping
+    public void requestWithdrawal (
+        @RequestBody Job2WorkerRequest request
     );
 
 

--- a/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.request.Job4WorkerRequest;
-import spot.spot.domain.job.dto.request.YesOrNoOfClientRequest;
+import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 
@@ -174,7 +174,7 @@ public interface Job4ClientDocs {
         })
     @PostMapping
     public void acceptJobRequestOfWorker (
-        @RequestBody YesOrNoOfClientRequest request
+        @RequestBody YesOrNo2WorkersRequest request
     );
 
 

--- a/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
@@ -160,6 +160,22 @@ public interface Job4ClientDocs {
         @RequestBody Job4WorkerRequest request
     );
 
+    @Operation(summary = "너 일해라",
+        description = """
+        일을 하겠다고 자원한 해결사 중 한명의 요청을 승낙하기 - 너 일해라
+        """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "(message : \"Success\")",
+                content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "404", description = """
+                (message : "그런 해결사가 존재하지 않습니다.")
+                """, content = @Content),
+        })
+    @PostMapping
+    public void acceptJobRequestOfWorker (
+        @RequestBody Job4WorkerRequest request
+    );
+
 
 
 }

--- a/src/main/java/spot/spot/domain/job/_docs/Job4WorkerDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4WorkerDocs.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-import spot.spot.domain.job.dto.request.Job4ClientRequest;
+import spot.spot.domain.job.dto.request.Job2WorkerRequest;
 import spot.spot.domain.job.dto.request.RegisterWorkerRequest;
 import spot.spot.domain.job.dto.request.YesOrNo2ClientsRequest;
 import spot.spot.domain.job.dto.response.NearByJobResponse;
@@ -130,10 +130,10 @@ public interface Job4WorkerDocs {
 
 
     @PostMapping
-    public void askingJob2Client(@RequestBody Job4ClientRequest request);
+    public void askingJob2Client(@RequestBody Job2WorkerRequest request);
 
     @PostMapping
-    public void startJob(@RequestBody Job4ClientRequest request);
+    public void startJob(@RequestBody Job2WorkerRequest request);
 
     @PostMapping
     public void acceptJobRequestOfClient (

--- a/src/main/java/spot/spot/domain/job/_docs/Job4WorkerDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4WorkerDocs.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import spot.spot.domain.job.dto.request.Job4ClientRequest;
 import spot.spot.domain.job.dto.request.RegisterWorkerRequest;
+import spot.spot.domain.job.dto.request.YesOrNo2ClientsRequest;
 import spot.spot.domain.job.dto.response.NearByJobResponse;
 
 @Tag(name = "Job4Worker", description = "해결사를 위한 API 모음")
@@ -134,6 +135,10 @@ public interface Job4WorkerDocs {
     @PostMapping
     public void startJob(@RequestBody Job4ClientRequest request);
 
+    @PostMapping
+    public void acceptJobRequestOfClient (
+        @RequestBody YesOrNo2ClientsRequest request
+    );
 
 
 }

--- a/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
@@ -17,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 import spot.spot.domain.job._docs.Job4ClientDocs;
 import spot.spot.domain.job.dto.request.Job4WorkerRequest;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
+import spot.spot.domain.job.dto.request.YesOrNoOfClientRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.job.service.Job4ClientService;
@@ -58,7 +59,7 @@ public class Job4ClientController implements Job4ClientDocs {
     }
 
     @PostMapping("/accept")
-    public void acceptJobRequestOfWorker(@RequestBody Job4WorkerRequest request) {
+    public void acceptJobRequestOfWorker(@RequestBody YesOrNoOfClientRequest request) {
         job4ClientService.acceptRequestOfWorker(request);
     }
 

--- a/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
@@ -15,7 +15,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import spot.spot.domain.job._docs.Job4ClientDocs;
-import spot.spot.domain.job.dto.request.Job4WorkerRequest;
+import spot.spot.domain.job.dto.request.Job2ClientRequest;
+import spot.spot.domain.job.dto.request.Job2WorkerRequest;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
@@ -54,13 +55,18 @@ public class Job4ClientController implements Job4ClientDocs {
 
 
     @PostMapping("/choice")
-    public void askJob2Worker(@RequestBody  Job4WorkerRequest request) {
+    public void askJob2Worker(@RequestBody Job2ClientRequest request) {
         job4ClientService.askingJob2Worker(request);
     }
 
     @PostMapping("/yes-or-no")
     public void acceptJobRequestOfWorker(@RequestBody YesOrNo2WorkersRequest request) {
         job4ClientService.yesOrNo2RequestOfWorker(request);
+    }
+
+    @PostMapping("/withdrawal")
+    public void requestWithdrawal(Job2WorkerRequest request) {
+
     }
 
 }

--- a/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
@@ -17,7 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 import spot.spot.domain.job._docs.Job4ClientDocs;
 import spot.spot.domain.job.dto.request.Job4WorkerRequest;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
-import spot.spot.domain.job.dto.request.YesOrNoOfClientRequest;
+import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.job.service.Job4ClientService;
@@ -58,9 +58,9 @@ public class Job4ClientController implements Job4ClientDocs {
         job4ClientService.askingJob2Worker(request);
     }
 
-    @PostMapping("/accept")
-    public void acceptJobRequestOfWorker(@RequestBody YesOrNoOfClientRequest request) {
-        job4ClientService.acceptRequestOfWorker(request);
+    @PostMapping("/yes-or-no")
+    public void acceptJobRequestOfWorker(@RequestBody YesOrNo2WorkersRequest request) {
+        job4ClientService.yesOrNo2RequestOfWorker(request);
     }
 
 }

--- a/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
@@ -1,6 +1,5 @@
 package spot.spot.domain.job.controller;
 
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -9,14 +8,15 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import spot.spot.domain.job._docs.Job4ClientDocs;
-import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.request.Job4WorkerRequest;
+import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.job.service.Job4ClientService;
@@ -50,8 +50,16 @@ public class Job4ClientController implements Job4ClientDocs {
         return job4ClientService.findJobAttenderList(id, pageable);
     }
 
+
+
     @PostMapping("/choice")
     public void askJob2Worker(@RequestBody  Job4WorkerRequest request) {
         job4ClientService.askingJob2Worker(request);
     }
+
+    @PostMapping("/accept")
+    public void acceptJobRequestOfWorker(@RequestBody Job4WorkerRequest request) {
+        job4ClientService.acceptRequestOfWorker(request);
+    }
+
 }

--- a/src/main/java/spot/spot/domain/job/controller/Job4WorkerController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4WorkerController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import spot.spot.domain.job._docs.Job4WorkerDocs;
-import spot.spot.domain.job.dto.request.Job4ClientRequest;
+import spot.spot.domain.job.dto.request.Job2WorkerRequest;
 import spot.spot.domain.job.dto.request.RegisterWorkerRequest;
 import spot.spot.domain.job.dto.request.YesOrNo2ClientsRequest;
 import spot.spot.domain.job.dto.response.NearByJobResponse;
@@ -45,12 +45,12 @@ public class Job4WorkerController implements Job4WorkerDocs {
     }
 
     @PostMapping("/request")
-    public void askingJob2Client(@RequestBody Job4ClientRequest request) {
+    public void askingJob2Client(@RequestBody Job2WorkerRequest request) {
         job4WorkerService.askingJob2Client(request);
     }
 
     @PostMapping("/start")
-    public void startJob(@RequestBody Job4ClientRequest request) {
+    public void startJob(@RequestBody Job2WorkerRequest request) {
         job4WorkerService.startJob(request);
     }
 

--- a/src/main/java/spot/spot/domain/job/controller/Job4WorkerController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4WorkerController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import spot.spot.domain.job._docs.Job4WorkerDocs;
 import spot.spot.domain.job.dto.request.Job4ClientRequest;
 import spot.spot.domain.job.dto.request.RegisterWorkerRequest;
+import spot.spot.domain.job.dto.request.YesOrNo2ClientsRequest;
 import spot.spot.domain.job.dto.response.NearByJobResponse;
 import spot.spot.domain.job.service.Job4WorkerService;
 
@@ -51,6 +52,11 @@ public class Job4WorkerController implements Job4WorkerDocs {
     @PostMapping("/start")
     public void startJob(@RequestBody Job4ClientRequest request) {
         job4WorkerService.startJob(request);
+    }
+
+    @PostMapping("/yes-or-no")
+    public void acceptJobRequestOfClient(YesOrNo2ClientsRequest request) {
+        job4WorkerService.yesOrNo2RequestOfClient(request);
     }
 
 

--- a/src/main/java/spot/spot/domain/job/dto/request/Job2ClientRequest.java
+++ b/src/main/java/spot/spot/domain/job/dto/request/Job2ClientRequest.java
@@ -2,7 +2,7 @@ package spot.spot.domain.job.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record Job4WorkerRequest(
+public record Job2ClientRequest(
     @Schema(description = "해결사가 맡으면 하는 일의 아이디")
     long jobId,
     @Schema(description = "해결사 dkdlel")

--- a/src/main/java/spot/spot/domain/job/dto/request/Job2WorkerRequest.java
+++ b/src/main/java/spot/spot/domain/job/dto/request/Job2WorkerRequest.java
@@ -2,7 +2,7 @@ package spot.spot.domain.job.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record Job4ClientRequest(
+public record Job2WorkerRequest(
     @Schema(description = "해결사가 맡아서 하고 싶은 일의 아이디")
     long jobId)
 { }

--- a/src/main/java/spot/spot/domain/job/dto/request/YesOrNo2ClientsRequest.java
+++ b/src/main/java/spot/spot/domain/job/dto/request/YesOrNo2ClientsRequest.java
@@ -1,0 +1,10 @@
+package spot.spot.domain.job.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record YesOrNo2ClientsRequest(
+    @Schema(description = "해결사가 맡으면 하는 일의 아이디")
+    long jobId,
+    @Schema(description = "true = YES, false = NO")
+    boolean isYes
+) { }

--- a/src/main/java/spot/spot/domain/job/dto/request/YesOrNo2WorkersRequest.java
+++ b/src/main/java/spot/spot/domain/job/dto/request/YesOrNo2WorkersRequest.java
@@ -2,10 +2,10 @@ package spot.spot.domain.job.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record YesOrNoOfClientRequest(
+public record YesOrNo2WorkersRequest(
     @Schema(description = "해결사가 맡으면 하는 일의 아이디")
     long jobId,
-    @Schema(description = "해결사 dkdlel")
+    @Schema(description = "해결사 아이디")
     long attenderId,
     @Schema(description = "true = YES, false = NO")
     boolean isYes

--- a/src/main/java/spot/spot/domain/job/dto/request/YesOrNoOfClientRequest.java
+++ b/src/main/java/spot/spot/domain/job/dto/request/YesOrNoOfClientRequest.java
@@ -1,0 +1,14 @@
+package spot.spot.domain.job.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record YesOrNoOfClientRequest(
+    @Schema(description = "해결사가 맡으면 하는 일의 아이디")
+    long jobId,
+    @Schema(description = "해결사 dkdlel")
+    long attenderId,
+    @Schema(description = "true = YES, false = NO")
+    boolean isYes
+) {
+
+}

--- a/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import spot.spot.domain.job.dto.request.Job4WorkerRequest;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
+import spot.spot.domain.job.dto.request.YesOrNoOfClientRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.job.entity.Job;
@@ -92,13 +93,13 @@ public class Job4ClientService {
 
 
     @Transactional
-    public void acceptRequestOfWorker(Job4WorkerRequest request) {
+    public void acceptRequestOfWorker(YesOrNoOfClientRequest request) {
         Member owner = userAccessUtil.getMember();
         Member worker = memberRepository
             .findById(request.attenderId()).orElseThrow(() -> new GlobalException(
             ErrorCode.MEMBER_NOT_FOUND));
         Job job = changeJobStatusDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.ATTENDER);
-        changeJobStatusDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.YES);
+        changeJobStatusDsl.updateMatchingStatus(worker.getId(), request.jobId(), request.isYes()? MatchingStatus.YES : MatchingStatus.NO);
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("일 시작 알림!").body(
             fcmUtil.requestAcceptedBody(owner.getNickname(), worker.getNickname(), job.getTitle())).build());
     }

--- a/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import spot.spot.domain.job.dto.request.Job4WorkerRequest;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
-import spot.spot.domain.job.dto.request.YesOrNoOfClientRequest;
+import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.job.entity.Job;
@@ -30,12 +30,6 @@ import spot.spot.domain.notification.service.FcmUtil;
 import spot.spot.global.response.format.ErrorCode;
 import spot.spot.global.response.format.GlobalException;
 import spot.spot.domain.member.repository.MemberQueryRepository;
-import spot.spot.domain.member.repository.MemberRepository;
-import spot.spot.domain.member.repository.WorkerRepository;
-import spot.spot.domain.notification.dto.response.FcmDTO;
-import spot.spot.domain.notification.service.FcmUtil;
-import spot.spot.global.response.format.ErrorCode;
-import spot.spot.global.response.format.GlobalException;
 import spot.spot.global.security.util.UserAccessUtil;
 import spot.spot.global.util.AwsS3ObjectStorage;
 
@@ -93,7 +87,7 @@ public class Job4ClientService {
 
 
     @Transactional
-    public void acceptRequestOfWorker(YesOrNoOfClientRequest request) {
+    public void yesOrNo2RequestOfWorker(YesOrNo2WorkersRequest request) {
         Member owner = userAccessUtil.getMember();
         Member worker = memberRepository
             .findById(request.attenderId()).orElseThrow(() -> new GlobalException(

--- a/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
@@ -84,7 +84,7 @@ public class Job4ClientService {
             .findById(request.attenderId()).orElseThrow(() -> new GlobalException(
             ErrorCode.MEMBER_NOT_FOUND));
         Job job = changeJobStatusDsl.findJobWithValidation(request.attenderId(), request.jobId());
-        Matching matching = Matching.builder().job(job).member(worker).status(MatchingStatus.ATTENDER).build();
+        Matching matching = Matching.builder().job(job).member(worker).status(MatchingStatus.REQUEST).build();
         matchingRepository.save(matching);
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("일 해결 신청 알림!").body(
             fcmUtil.askRequest2WorkerMsg(worker.getNickname(), job.getTitle())).build());

--- a/src/main/java/spot/spot/domain/job/service/Job4WorkerService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4WorkerService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spot.spot.domain.job.dto.request.Job4ClientRequest;
 import spot.spot.domain.job.dto.request.RegisterWorkerRequest;
+import spot.spot.domain.job.dto.request.YesOrNo2ClientsRequest;
+import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.NearByJobResponse;
 import spot.spot.domain.job.entity.Job;
 import spot.spot.domain.job.entity.Matching;
@@ -94,6 +96,14 @@ public class Job4WorkerService {
         Job job = changeJobStatusDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.YES);
         changeJobStatusDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.START);
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("일 시작 알림!").body(
+            fcmUtil.getStartedJobMsg(worker.getNickname(), job.getTitle())).build());
+    }
+
+    public void yesOrNo2RequestOfClient(YesOrNo2ClientsRequest request) {
+        Member worker = userAccessUtil.getMember();
+        Job job = changeJobStatusDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.REQUEST);
+        changeJobStatusDsl.updateMatchingStatus(worker.getId(), request.jobId(), request.isYes()? MatchingStatus.YES : MatchingStatus.NO);
+        fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("요청 승낙 알림!").body(
             fcmUtil.getStartedJobMsg(worker.getNickname(), job.getTitle())).build());
     }
 }

--- a/src/main/java/spot/spot/domain/job/service/Job4WorkerService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4WorkerService.java
@@ -91,6 +91,7 @@ public class Job4WorkerService {
             fcmUtil.askRequest2ClientMsg(worker.getNickname(), job.getTitle())).build());
     }
     // 일 시작하기
+    @Transactional
     public void startJob (Job4ClientRequest request) {
         Member worker = userAccessUtil.getMember();
         Job job = changeJobStatusDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.YES);
@@ -99,6 +100,7 @@ public class Job4WorkerService {
             fcmUtil.getStartedJobMsg(worker.getNickname(), job.getTitle())).build());
     }
 
+    @Transactional
     public void yesOrNo2RequestOfClient(YesOrNo2ClientsRequest request) {
         Member worker = userAccessUtil.getMember();
         Job job = changeJobStatusDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.REQUEST);

--- a/src/main/java/spot/spot/domain/job/service/Job4WorkerService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4WorkerService.java
@@ -6,10 +6,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import spot.spot.domain.job.dto.request.Job4ClientRequest;
+import spot.spot.domain.job.dto.request.Job2WorkerRequest;
 import spot.spot.domain.job.dto.request.RegisterWorkerRequest;
 import spot.spot.domain.job.dto.request.YesOrNo2ClientsRequest;
-import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.NearByJobResponse;
 import spot.spot.domain.job.entity.Job;
 import spot.spot.domain.job.entity.Matching;
@@ -82,7 +81,7 @@ public class Job4WorkerService {
                 jobRepository.findById(jobId).orElseThrow(() -> new GlobalException(ErrorCode.JOB_NOT_FOUND)));
     }
     // 일 신청하기
-    public void askingJob2Client(Job4ClientRequest request) {
+    public void askingJob2Client(Job2WorkerRequest request) {
         Member worker = userAccessUtil.getMember();
         Job job = changeJobStatusDsl.findJobWithValidation(worker.getId(), request.jobId());
         Matching matching = Matching.builder().job(job).member(worker).status(MatchingStatus.ATTENDER).build();
@@ -92,7 +91,7 @@ public class Job4WorkerService {
     }
     // 일 시작하기
     @Transactional
-    public void startJob (Job4ClientRequest request) {
+    public void startJob (Job2WorkerRequest request) {
         Member worker = userAccessUtil.getMember();
         Job job = changeJobStatusDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.YES);
         changeJobStatusDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.START);

--- a/src/main/java/spot/spot/domain/notification/service/FcmUtil.java
+++ b/src/main/java/spot/spot/domain/notification/service/FcmUtil.java
@@ -81,4 +81,8 @@ public class FcmUtil  {
         return attenderName + "님이 " + jobName + "을 시작합니다!";
     }
 
+    public String requestAcceptedBody (String owner_name, String attender_name, String jobName){
+        return owner_name + "님이 " + jobName + "에 대한 " + attender_name + "님의 요청을 승낙하셨습니다!";
+    }
+
 }

--- a/src/main/java/spot/spot/global/response/handler/GlobalExceptionHandler.java
+++ b/src/main/java/spot/spot/global/response/handler/GlobalExceptionHandler.java
@@ -33,7 +33,9 @@ public class GlobalExceptionHandler {
     // 예기치 못한 에러 발생 시 (일단 에러 내용이 front 한테도 보이게 뒀습니다. 배포할 때 고치겠습니다.
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ResultResponse<Object>> handleUnExpectException (Exception e) {
+        ColorLogger.red("{},", e.getCause());
         ColorLogger.red("{}",e.getMessage());
+
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .headers(jsonHeaders)


### PR DESCRIPTION
# 💡 Issue
 - resolved #89 

# 🌱 Key changes
- [x] 기본 로직 재활용 했습니다.
- [x] 10분동안 SLEEP 상태일 시, CANCELL 시키고, 그 사이에 해결사가 API 요청을 보내면 다시 START로 바뀌도록 비동기 스케줄링을 다음 PR에 적용하겠습니다.

# ✅ To Reviewers

다음으로 출발~

# 📸 스크린샷
