### PR TITLE
FEAT: 노쇼한 해결사 일 철회 시키기 (의뢰자가 철회 요청 -> 10분 간 해결사에게서 아무 응답이 없으면 취소) 

### DIFF
--- a/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
@@ -183,7 +183,7 @@ public interface Job4ClientDocs {
 
     @Operation(summary = "일 철회 요청",
         description = """
-        잠수탄 놈에 대해 일 철회 요청
+        잠수탄 놈에 대해 일 철회 요청 (SLEEP 처리 -> 10분 후 CANCEL로 조절)
         """,
         responses = {
             @ApiResponse(responseCode = "200", description = "(message : \"Success\")",

--- a/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
@@ -181,9 +181,20 @@ public interface Job4ClientDocs {
     );
 
 
+    @Operation(summary = "일 철회 요청",
+        description = """
+        잠수탄 놈에 대해 일 철회 요청
+        """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "(message : \"Success\")",
+                content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "404", description = """
+                (message : "그런 해결사가 존재하지 않습니다.")
+                """, content = @Content),
+        })
     @PostMapping
     public void requestWithdrawal (
-        @RequestBody Job2WorkerRequest request
+        @RequestBody Job2ClientRequest request
     );
 
 

--- a/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
@@ -67,8 +67,8 @@ public class Job4ClientController implements Job4ClientDocs {
     }
 
     @PostMapping("/withdrawal")
-    public void requestWithdrawal(Job2WorkerRequest request) {
-
+    public void requestWithdrawal(Job2ClientRequest request) {
+        job4ClientService.requestWithdrawal(request);
     }
 
 }

--- a/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
@@ -111,7 +111,7 @@ public class Job4ClientService {
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("일 시작 알림!").body(
             fcmUtil.requestAcceptedBody(owner.getNickname(), worker.getNickname(), job.getTitle())).build());
     }
-    // 일 취소 요창
+    // 일 철회 요청
     @Transactional
     public void requestWithdrawal(Job2ClientRequest request) {
         Member owner = userAccessUtil.getMember();
@@ -119,7 +119,8 @@ public class Job4ClientService {
             .findById(request.attenderId()).orElseThrow(() -> new GlobalException(
                 ErrorCode.MEMBER_NOT_FOUND));
         Job job = changeJobStatusDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.START);
-        changeJobStatusDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.SLEEP);
+        Matching matching = changeJobStatusDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.SLEEP);
+        jobUtil.scheduledSleepMatching2Cancel(matching);
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("혹시 잠수 타셨나요??").body(
             fcmUtil.requestAcceptedBody(owner.getNickname(), worker.getNickname(), job.getTitle())).build());
     }

--- a/src/main/java/spot/spot/domain/job/service/Job4WorkerService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4WorkerService.java
@@ -102,7 +102,7 @@ public class Job4WorkerService {
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("일 시작 알림!").body(
                 fcmUtil.getStartedJobMsg(worker.getNickname(), job.getTitle())).build());
     }
-
+    // 의뢰인이 보낸 요청 승낙하기 혹은 거절하기
     @Transactional
     public void yesOrNo2RequestOfClient(YesOrNo2ClientsRequest request) {
         Member worker = userAccessUtil.getMember();

--- a/src/main/java/spot/spot/domain/job/service/JobUtil.java
+++ b/src/main/java/spot/spot/domain/job/service/JobUtil.java
@@ -1,11 +1,35 @@
 package spot.spot.domain.job.service;
 
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.mapstruct.Named;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+import spot.spot.domain.job.entity.Matching;
+import spot.spot.domain.job.entity.MatchingStatus;
+import spot.spot.domain.job.repository.dsl.ChangeJobStatusDsl;
+import spot.spot.domain.job.repository.jpa.MatchingRepository;
+import spot.spot.global.logging.ColorLogger;
+import spot.spot.global.response.format.ErrorCode;
+import spot.spot.global.response.format.GlobalException;
 import spot.spot.global.util.ConstantUtil;
-
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class JobUtil {
+
+    private final ThreadPoolTaskScheduler taskScheduler;
+    private final MatchingRepository matchingRepository;
+    private final Map<Long, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+    private final TransactionTemplate transactionTemplate;
+    private final ChangeJobStatusDsl changeJobStatusDsl;
 
     // 줌 레벨을 실제 KM로 변환하는 함수
     public double convertZoomToRadius(int zoom_level) {
@@ -37,5 +61,46 @@ public class JobUtil {
         double distance_radian = 2 * Math.atan2(Math.sqrt(distance_ratio), Math.sqrt(1 - distance_ratio));
 
         return ConstantUtil.EARTH_RADIUS_KM * distance_radian;
+    }
+    // SLEEP 상태로 돌아선 MATCHING RECORD를 10분 뒤에 취소로 바꾸는 비동기 로직
+    public void scheduledSleepMatching2Cancel(Matching matching) {
+        long matching_id = matching.getId();
+        if(scheduledTasks.containsKey(matching_id)) {
+            log.info("취소하려는 매칭이 이미 스케줄 예약이 걸려 있습니다. id= {} 따라서 새로운 취소 예약 작업은 종료됩니다.", matching_id);
+            return;
+        }
+
+        ScheduledFuture<?> future = taskScheduler.schedule(
+            () -> executeCancel(matching_id),
+            Instant.now().plusSeconds(600));
+
+        scheduledTasks.put(matching_id, future);
+        ColorLogger.green("Matching-{}는 10분 후 취소 예약 설정 되었습니다. SIGN-OK ", matching_id);
+
+
+    }
+
+    public void executeCancel(long matching_id) {
+        transactionTemplate.execute(status -> {
+            Matching matching = matchingRepository.findById(matching_id).orElseThrow(() -> new GlobalException(
+                ErrorCode.MATCHING_NOT_FOUND));
+            if(matching.getStatus() != MatchingStatus.SLEEP) {
+                ColorLogger.red("더 이상 잠수 상태가 아닌 해결사-일 Matching-{}은 skip 합니다. ", matching_id);
+                return -1;
+            }
+            changeJobStatusDsl.updateMatchingStatus(matching_id, MatchingStatus.CANCEL);
+            scheduledTasks.remove(matching_id);
+            log.info("Matching-{}는 해결사의 노쇼로 인해 취소되었음을 알립니다.", matching_id);
+            return 0;
+        });
+    }
+
+    // 스케줄링에 이미 들어간 매칭을 스케줄러에서 빼내기 -> 취소 작업 철회
+    public void withdrawalExistingScheduledTask(long matchingId) {
+        ScheduledFuture<?> future = scheduledTasks.remove(matchingId);  // 맵에서 해당 Future 객체 삭제
+        if(future != null) {    // 맵에 있었다면 future는 null이 아님.
+            future.cancel(false);   // 해당 Future 객체의 예약 취소
+            log.info("Matching-id: {}를 취소 예약이 철회되었습니다.", matchingId);
+        }
     }
 }

--- a/src/main/java/spot/spot/domain/job/service/JobUtil.java
+++ b/src/main/java/spot/spot/domain/job/service/JobUtil.java
@@ -72,7 +72,7 @@ public class JobUtil {
 
         ScheduledFuture<?> future = taskScheduler.schedule(
             () -> executeCancel(matching_id),
-            Instant.now().plusSeconds(600));
+            Instant.now().plusSeconds(60));
 
         scheduledTasks.put(matching_id, future);
         ColorLogger.green("Matching-{}는 10분 후 취소 예약 설정 되었습니다. SIGN-OK ", matching_id);

--- a/src/main/java/spot/spot/domain/job/service/JobUtil.java
+++ b/src/main/java/spot/spot/domain/job/service/JobUtil.java
@@ -72,7 +72,7 @@ public class JobUtil {
 
         ScheduledFuture<?> future = taskScheduler.schedule(
             () -> executeCancel(matching_id),
-            Instant.now().plusSeconds(60));
+            Instant.now().plusSeconds(600));
 
         scheduledTasks.put(matching_id, future);
         ColorLogger.green("Matching-{}는 10분 후 취소 예약 설정 되었습니다. SIGN-OK ", matching_id);

--- a/src/main/java/spot/spot/global/response/format/ErrorCode.java
+++ b/src/main/java/spot/spot/global/response/format/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     FAILED_2_UPDATE_JOB_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "상태 변경에 실패했습니다."),
     DIDNT_PASS_VALIDATION(HttpStatus.BAD_REQUEST, "요청이 유효성 검증을 통과하지 못했습니다. (1. 구직자 등록 x, 2. 매칭 상태가 현재 요청을 이룰 수 없음, 3. 이미 해당 일을 진행하는 사람임"),
     JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "찾으시는 일은 존재하지 않습니다."),
+    MATCHING_NOT_FOUND(HttpStatus.NOT_FOUND, "찾으시는 매칭이 존재하지 않습니다."),
     JOB_IS_ALREADY_STARTED(HttpStatus.NOT_FOUND, "신청 하시려는 일은 이미 시작되었습니다."),
     INVALID_DISTANCE(HttpStatus.BAD_REQUEST, "지도 축소가 너무 과합니다. (◞‸ ◟)"),
     FAIL_PAY_READY(HttpStatus.BAD_GATEWAY, "카카오페이 API 요청이 실패하였습니다."),

--- a/src/main/java/spot/spot/global/scheduler/SchedulingConfig.java
+++ b/src/main/java/spot/spot/global/scheduler/SchedulingConfig.java
@@ -1,0 +1,19 @@
+package spot.spot.global.scheduler;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulingConfig { // 비동기 스케줄러는 비동기 쓰레드와 다르게 풀 사이즈가 고정이고 기본적으로 큐가 없다. -> 커스텀 하면 가능
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);  // 동시에 실행할 스레드 수 설정
+        scheduler.setThreadNamePrefix("scheduled-task-"); //스레드 이름 접두사
+        scheduler.setAwaitTerminationSeconds(60);
+        scheduler.setWaitForTasksToCompleteOnShutdown(true); //작업 완료까지 스프링종료를 대기
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/main/java/spot/spot/global/scheduler/SchedulingTask.java
+++ b/src/main/java/spot/spot/global/scheduler/SchedulingTask.java
@@ -1,0 +1,24 @@
+package spot.spot.global.scheduler;
+
+import java.util.function.Consumer;
+import lombok.AllArgsConstructor;
+import org.springframework.transaction.support.TransactionTemplate;
+
+// runnable을 구현한 클래스는 스레드에서 실행될 수 있는 작업이됨.
+// threadPoolTashScheduler에게 이 구현체의 객체를 넘기면 특정 시간 후 실행됨
+@AllArgsConstructor
+public class SchedulingTask<T> implements Runnable{
+
+    private final T target;                                 // 작업 실행 시 사용하는 객체
+    private final Consumer<T> task;                         // 실행할 작업 자체
+    private final TransactionTemplate transactionTemplate;  // 트랜잭션 관리 도구 - 트랜잭션을 직접 제어 및 관리할 수 있게 도와줌
+
+
+    @Override
+    public void run() {
+        transactionTemplate.execute(status -> { // 이 템플릿 안에서만 트랜잭션 적용되어 영속성을 유지함.
+            task.accept(target);                // 특정 에러 발생시 작업을 롤백, 데이터 손상 방지
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
# 💡 Issue
- resolved close #90 

# 🌱 Key changes
- [x] 1. 비동기 스케줄링 시스템 완성
- [x] 2. 취소 예약 10분 후 백그라운드 스레드에서 실행되도록 조치
- [x] 3. 취소 철회 요청이 들어오면 백그라운드 스레드에서 실행 전, Executor 내부 우선순위 큐와 concurrent hashMap에서 삭제






# ✅ To Reviewers
비동기 스케줄링의 과정을 한 번 보시고 자신의 코드가 들어가야할 부분을 생각해보고, 코드 같이 수정해봐요^^

## 비동기 스케줄링의 과정

### 1. 일의 의뢰자(이하 client) 쪽에서 해결사 취소 요청을 보낸다.
![image](https://github.com/user-attachments/assets/204db73e-523a-4556-a0e9-6458a54cec3c)
그러면 Main Thread에서 취소 예약을 `ThreadPoolSchedulingExecutor` 와 `ConcurrentHashMap`에 저장

### 2. 10분 동안 취소 철회 요청이 들어오지 않고, 취소가 실행되는 경우
우선순위 큐는 TimeStamp가 가까운 순으로 값을 정렬시키기 때문에 실행 되어야 할 시간이 임박할수록 큐의 front로 오게됨.
![image](https://github.com/user-attachments/assets/21f299b8-d020-40da-b8fe-30aa8d0eb2ee)
이후 빈 백그라운드 스레드에서 일 실행

### 3. 만약 10분 사이에 해결사로부터 잠수 해제 및 일 재개 요청이 들어왔을 경우
![image](https://github.com/user-attachments/assets/e932ac3e-2ca8-455d-8ee8-473e307ad65f)

취소 철회 요청이 들어온 matching-id로 일을 찾고, 해당 일을 Map에서 지움 (Map은 취소 예약된 일을 추적하기 위한 용도) 
우리는 찾은 ConcurrentHashMap을 우선순위 큐에서도 삭제 (우선순위 큐 전체를 돌아야 해서 최악의 시간복잡도 O(N)이 든다.)

### 4. ERROR, 만약 취소 예약이 이미 들어갔는데, 취소 요청을 또 한 경우
![image](https://github.com/user-attachments/assets/4a6add7a-64ce-4d39-94d6-e71a8584b248)
취소 예약 밀어넣기 전에 혹시 현재 삭제예약이 걸려 있는지 확인 합니다.


위와 같이 진행되었습니다.
혹시 본인 도메인에서 쓰셔야할 부분이나, 로직적으로 수정해야할 부분이 있으면 이야기 해주시요. 같이 토의해봐요^^

# 📸 스크린샷

## 테스트
테스트는 취소 예약을 1분으로 걸어놓고 해보았습니다.
![image](https://github.com/user-attachments/assets/ba7d056c-71cb-4b5d-9bc5-406b8b182f7c)
![image](https://github.com/user-attachments/assets/1cd81af3-e318-42ac-ad07-b76b2282edab)

저번 PR에서의 조치로 SLEEP 상태였던 5번 유저를 취소시켰습니다.
![image](https://github.com/user-attachments/assets/8025a345-cc92-42e5-98f6-75a4d5685aba)



