### PR TITLE
FIX: 일 처리 실시간 확인 페이지 -> 일 하나 확인하기로 API 통일

### DIFF
--- a/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
@@ -21,6 +21,7 @@ import spot.spot.domain.job.dto.request.Job2ClientRequest;
 import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.JobResponse;
+import spot.spot.domain.job.dto.response.JobSituationResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.pay.entity.dto.response.PayReadyResponseDto;
 
@@ -210,4 +211,26 @@ public interface Job4ClientDocs {
         })
     @GetMapping
     public JobResponse getJobDetail(@RequestParam long jobId);
+
+    @Operation(summary = "내가 맡긴 일의 현황 보기",
+        description = """
+   
+        jobId,
+        title,
+        img,
+        content,
+        status,
+        memberId,
+        nickName,
+        phone
+        """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "(message : \"Success\")",
+                content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "404", description = """
+                (message : "그런 해결사가 존재하지 않습니다.")
+                """, content = @Content),
+        })
+    @GetMapping
+    public List<JobSituationResponse> getSituationByOwner();
 }

--- a/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
@@ -198,20 +198,6 @@ public interface Job4ClientDocs {
         @RequestBody Job2ClientRequest request
     );
 
-    @Operation(summary = "일 하나 상세 보기 (의뢰인 용)",
-        description = """
-        일 하나 상세보기
-        """,
-        responses = {
-            @ApiResponse(responseCode = "200", description = "(message : \"Success\")",
-                content = @Content(schema = @Schema(implementation = String.class))),
-            @ApiResponse(responseCode = "404", description = """
-                (message : "그런 해결사가 존재하지 않습니다.")
-                """, content = @Content),
-        })
-    @GetMapping
-    public JobResponse getJobDetail(@RequestParam long jobId);
-
     @Operation(summary = "내가 맡긴 일의 현황 보기",
         description = """
    

--- a/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
+++ b/src/main/java/spot/spot/domain/job/_docs/Job4ClientDocs.java
@@ -20,6 +20,7 @@ import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.request.Job2ClientRequest;
 import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
+import spot.spot.domain.job.dto.response.JobResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.pay.entity.dto.response.PayReadyResponseDto;
 
@@ -196,6 +197,17 @@ public interface Job4ClientDocs {
         @RequestBody Job2ClientRequest request
     );
 
-
-
+    @Operation(summary = "일 하나 상세 보기 (의뢰인 용)",
+        description = """
+        일 하나 상세보기
+        """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "(message : \"Success\")",
+                content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "404", description = """
+                (message : "그런 해결사가 존재하지 않습니다.")
+                """, content = @Content),
+        })
+    @GetMapping
+    public JobResponse getJobDetail(@RequestParam long jobId);
 }

--- a/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
@@ -72,11 +72,6 @@ public class Job4ClientController implements Job4ClientDocs {
         job4ClientService.requestWithdrawal(request);
     }
 
-    @GetMapping("/detail")
-    public JobResponse getJobDetail(@RequestParam  long jobId) {
-        return null;
-    }
-
     @GetMapping("/dash-board")
     public List<JobSituationResponse> getSituationByOwner() {
         return job4ClientService.getSituationsByOwner();

--- a/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
@@ -20,6 +20,7 @@ import spot.spot.domain.job.dto.request.Job2WorkerRequest;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
+import spot.spot.domain.job.dto.response.JobResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.job.service.Job4ClientService;
 import spot.spot.domain.pay.entity.dto.response.PayReadyResponseDto;
@@ -68,6 +69,11 @@ public class Job4ClientController implements Job4ClientDocs {
     @PostMapping("/withdrawal")
     public void requestWithdrawal(Job2ClientRequest request) {
         job4ClientService.requestWithdrawal(request);
+    }
+
+    @GetMapping("/detail")
+    public JobResponse getJobDetail(@RequestParam  long jobId) {
+        return null;
     }
 
 }

--- a/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
+++ b/src/main/java/spot/spot/domain/job/controller/Job4ClientController.java
@@ -21,6 +21,7 @@ import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.JobResponse;
+import spot.spot.domain.job.dto.response.JobSituationResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.job.service.Job4ClientService;
 import spot.spot.domain.pay.entity.dto.response.PayReadyResponseDto;
@@ -74,6 +75,11 @@ public class Job4ClientController implements Job4ClientDocs {
     @GetMapping("/detail")
     public JobResponse getJobDetail(@RequestParam  long jobId) {
         return null;
+    }
+
+    @GetMapping("/dash-board")
+    public List<JobSituationResponse> getSituationByOwner() {
+        return job4ClientService.getSituationsByOwner();
     }
 
 }

--- a/src/main/java/spot/spot/domain/job/dto/response/JobResponse.java
+++ b/src/main/java/spot/spot/domain/job/dto/response/JobResponse.java
@@ -1,0 +1,21 @@
+package spot.spot.domain.job.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record JobResponse(
+    @Schema(description = "위도")
+    double lat,
+    @Schema(description = "경도")
+    double lng,
+    @Schema(description = "제목")
+    String titie,
+    @Schema(description = "내용물")
+    String content,
+    @Schema(description = "금액")
+    int money,
+    @Schema(description = "일의 이미지")
+    String img,
+    @Schema(description = "시작 시간")
+    LocalDateTime startedAt
+) {}

--- a/src/main/java/spot/spot/domain/job/dto/response/JobSituationResponse.java
+++ b/src/main/java/spot/spot/domain/job/dto/response/JobSituationResponse.java
@@ -1,0 +1,31 @@
+package spot.spot.domain.job.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import spot.spot.domain.job.entity.MatchingStatus;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class JobSituationResponse {
+    @Schema(description = "일 아이디")
+    private long jobId;
+    @Schema(description = "일 제목")
+    private String title;
+    @Schema(description = "일의 이미지")
+    private String img;
+    @Schema(description = "일의 내용")
+    private String content;
+    @Schema(description = "일의 현황")
+    private MatchingStatus status;
+    @Schema(description = "해결사 아이디")
+    private long memberId;
+    @Schema(description = "해결사 이름")
+    private String nickName;
+    @Schema(description = "해결사 전화번호")
+    private String phone;
+}

--- a/src/main/java/spot/spot/domain/job/mapper/Job4ClientMapper.java
+++ b/src/main/java/spot/spot/domain/job/mapper/Job4ClientMapper.java
@@ -20,7 +20,6 @@ public interface Job4ClientMapper {
     * 3) 2번의 리스트 형태
     * 4) 3번 변환 시, 일에 필요한 능력을 교차테이블을 통해 String으로 변환하여 매핑하는 매소드
     * */
-
     // 1) 일 등록  (reqeust -> entity)
     @Mapping(source = "tid", target = "tid")
     @Mapping(source = "payHistory", target = "payment")

--- a/src/main/java/spot/spot/domain/job/mapper/Job4ClientMapper.java
+++ b/src/main/java/spot/spot/domain/job/mapper/Job4ClientMapper.java
@@ -20,6 +20,7 @@ public interface Job4ClientMapper {
     * 3) 2번의 리스트 형태
     * 4) 3번 변환 시, 일에 필요한 능력을 교차테이블을 통해 String으로 변환하여 매핑하는 매소드
     * */
+
     // 1) 일 등록  (reqeust -> entity)
     @Mapping(source = "tid", target = "tid")
     @Mapping(source = "payHistory", target = "payment")

--- a/src/main/java/spot/spot/domain/job/mapper/Job4ClientMapper.java
+++ b/src/main/java/spot/spot/domain/job/mapper/Job4ClientMapper.java
@@ -14,10 +14,18 @@ import spot.spot.domain.pay.entity.PayHistory;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface Job4ClientMapper {
+    /*
+    * 1) 일 등록 (reqeust -> entity)
+    * 2) 일 신청자 하나 변환 (entity -> response)
+    * 3) 2번의 리스트 형태
+    * 4) 3번 변환 시, 일에 필요한 능력을 교차테이블을 통해 String으로 변환하여 매핑하는 매소드
+    * */
+
+    // 1) 일 등록  (reqeust -> entity)
     @Mapping(source = "tid", target = "tid")
     @Mapping(source = "payHistory", target = "payment")
     Job registerRequestToJob (String img, RegisterJobRequest request, String tid, PayHistory payHistory);
-
+    // 2) 일 신청자 하나 변환 (entity -> response)
     @Mapping(source = "member.id", target = "id")
     @Mapping(source = "member.nickname", target = "name")
     @Mapping(source = "member.img", target = "profile_img")
@@ -25,20 +33,17 @@ public interface Job4ClientMapper {
     @Mapping(source = "member.lng", target = "lng")
     @Mapping(source = "workerAbilities", target = "abilities", qualifiedByName = "mapAbilities")
     AttenderResponse toResponse(Worker worker);
-
+    // 3) 2번의 List 형태
     @IterableMapping(elementTargetType = AttenderResponse.class)
     List<AttenderResponse> toResponseList(List<Worker> workers);
-
+    // 4) 3번 변환 시, 일에 필요한 능력을 교차테이블을 통해 String으로 변환하여 매핑하는 매소드
     @Named("mapAbilities")
     default List<String> mapAbilities(List<WorkerAbility> workerAbilities) {
         return workerAbilities != null
             ? workerAbilities.stream()
-            .map(workerAbility -> workerAbility.getAbility().getType().name()) // ✅ Ability의 name 값만 변환
+            .map(workerAbility -> workerAbility.getAbility().getType().name())
             .distinct() // ✅ 중복 제거
             .collect(Collectors.toList())
             : Collections.emptyList();
     }
-
-
-
 }

--- a/src/main/java/spot/spot/domain/job/mapper/Job4ClientMapper.java
+++ b/src/main/java/spot/spot/domain/job/mapper/Job4ClientMapper.java
@@ -1,5 +1,6 @@
 package spot.spot.domain.job.mapper;
 
+import com.querydsl.core.Tuple;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -7,6 +8,7 @@ import java.util.stream.Collectors;
 import org.mapstruct.*;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
+import spot.spot.domain.job.dto.response.JobSituationResponse;
 import spot.spot.domain.job.entity.Job;
 import spot.spot.domain.member.entity.Worker;
 import spot.spot.domain.member.entity.WorkerAbility;

--- a/src/main/java/spot/spot/domain/job/mapper/Job4WorkerMapper.java
+++ b/src/main/java/spot/spot/domain/job/mapper/Job4WorkerMapper.java
@@ -20,18 +20,26 @@ import spot.spot.domain.member.entity.WorkerAbility;
 import spot.spot.domain.member.repository.AbilityRepository;
 
 
-@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE, uses = {
-    AbilityRepository.class, JobUtil.class})
+@Mapper(componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE, uses = {AbilityRepository.class, JobUtil.class})
 public interface Job4WorkerMapper {
 
+    /*
+    *   1) 구직자 등록 (request -> entity)
+    *   2) 근처 일 하나 변환 (entity -> response)
+    *   3) Worker가 입력한 자신의 능력들과 Worker 본인을 교차테이블로 연관관계 짓기 (default)
+    *   4) 2번을 List로 변환
+    * */
+
+    // 1) Registing request to Entity
     @Mapping(target = "member", source = "member")
     @Mapping(target = "introduction", source = "request.content")
     @Mapping(target = "workerAbilities", ignore = true) // WorkerAbility 매핑은 별도 처리
     Worker dtoToWorker(RegisterWorkerRequest request, Member member);
+    // 2) 근처 일 하나 변환 (entity to response)
     @Mapping(target = "dist", ignore = true)
     NearByJobResponse toNearByJobResponse(Job job);
-
-    // 해결사 입력시 선택한 자신의 능력과 해결사를 교차테이블로 연관관계 잇기 위한 default 함수
+    // 3) Worker가 입력한 자신의 능력들과 Worker 본인을 교차테이블로 연관관계 짓기 (default)
     default List<WorkerAbility> mapWorkerAbilities(List<AbilityType> strong, Worker worker, AbilityRepository abilityRepository) {
         if(strong == null || strong.isEmpty()) return new ArrayList<>();
         return strong.stream()
@@ -46,7 +54,7 @@ public interface Job4WorkerMapper {
             })
             .collect(Collectors.toList());
     }
-
+    // 4) 2번을 리스트로 변환
     default List<NearByJobResponse> toNearByJobResponseList(List<Job> jobs, Location location) {
         return jobs.stream()
             .map(job -> {

--- a/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
@@ -2,6 +2,7 @@ package spot.spot.domain.job.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -13,6 +14,7 @@ import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
 import spot.spot.domain.job.dto.response.JobResponse;
+import spot.spot.domain.job.dto.response.JobSituationResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.job.entity.Job;
 import spot.spot.domain.job.entity.Matching;
@@ -37,6 +39,7 @@ import spot.spot.global.response.format.GlobalException;
 import spot.spot.global.security.util.UserAccessUtil;
 import spot.spot.global.util.AwsS3ObjectStorage;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class Job4ClientService {
@@ -143,5 +146,10 @@ public class Job4ClientService {
     // 8) 일 하나 상세 보기
     public JobResponse getJobDetail(long jobId) {
         return  null;
+    }
+    // 9) 내가 맡긴 일 현황 보기
+    public List<JobSituationResponse> getSituationsByOwner() {
+        Member owner = userAccessUtil.getMember();
+        return searchingListDsl.findJobSituationsByOwner(owner.getId());
     }
 }

--- a/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
+++ b/src/main/java/spot/spot/domain/job/service/Job4ClientService.java
@@ -12,6 +12,7 @@ import spot.spot.domain.job.dto.request.Job2ClientRequest;
 import spot.spot.domain.job.dto.request.RegisterJobRequest;
 import spot.spot.domain.job.dto.request.YesOrNo2WorkersRequest;
 import spot.spot.domain.job.dto.response.AttenderResponse;
+import spot.spot.domain.job.dto.response.JobResponse;
 import spot.spot.domain.job.dto.response.NearByWorkersResponse;
 import spot.spot.domain.job.entity.Job;
 import spot.spot.domain.job.entity.Matching;
@@ -39,22 +40,37 @@ import spot.spot.global.util.AwsS3ObjectStorage;
 @Service
 @RequiredArgsConstructor
 public class Job4ClientService {
+    // Util
+    private final JobUtil jobUtil;
     private final UserAccessUtil userAccessUtil;
+    private final AwsS3ObjectStorage awsS3ObjectStorage;
+    // Mapper
     private final Job4ClientMapper job4ClientMapper;
     private final MemberMapper memberMapper;
-    private final AwsS3ObjectStorage awsS3ObjectStorage;
     private final JobRepository jobRepository;
+    // JPA
     private final MatchingRepository matchingRepository;
     private final MemberQueryRepository memberQueryRepository;
-    private final JobUtil jobUtil;
-    // query dsl
+    // Query dsl
     private final SearchingListDsl searchingListDsl;
     private final ChangeJobStatusDsl changeJobStatusDsl;
     private final FcmUtil fcmUtil;
     private final PayService payService;
     private final MemberRepository memberRepository;
 
+    /*
+    *               [ 목차 ]
+    *       1. 일 등록 서비스
+    *       2. 근처 해결사 라스트 불러오기
+    *       3. 일 신청자 리스트 불러오기
+    *       4. Worker에게 일 의뢰하기
+    *       5. Worker의 일 신청 수락 혹은 거절하기
+    *       6. Worker의 일 철회 요청
+    *       7. 결제 내역으로 일 찾기
+    *       8. 일 하나 상세 확인하기
+    * */
 
+    // 1) 일 등록
     public PayReadyResponseDto registerJob(RegisterJobRequest request, MultipartFile file) {
         String url = awsS3ObjectStorage.uploadFile(file);
         Member client = userAccessUtil.getMember();
@@ -71,22 +87,18 @@ public class Job4ClientService {
         matchingRepository.save(matching);
         return payReadyResponseDto;
     }
-
+    // 2) 근처 해결사 찾기
     public List<NearByWorkersResponse> findNearByWorkers(double lat, double lng, int zoomLevel) {
         return memberMapper.toDtoList(memberQueryRepository.findWorkerNearByMember(lat, lng, jobUtil.convertZoomToRadius(zoomLevel)));
     }
-
+    // 3) 신청자 리스트 찾기
     @Transactional(readOnly = true)
     public Slice<AttenderResponse> findJobAttenderList(long jobId, Pageable pageable) {
         Slice<Worker> workers = searchingListDsl.findWorkersByJobIdAndStatus(jobId, pageable);
         List<AttenderResponse> responseList = job4ClientMapper.toResponseList(workers.getContent());
         return new SliceImpl<>(responseList, pageable, workers.hasNext());
     }
-
-    public Job findByTid(String tid) {
-        return jobRepository.findByTid(tid).orElseThrow(() -> new GlobalException(ErrorCode.INVALID_TITLE));
-    }
-
+    // 4) 해결사에게 일 의뢰
     public void askingJob2Worker (Job2ClientRequest request) {
         Member worker = memberRepository
             .findById(request.attenderId()).orElseThrow(() -> new GlobalException(
@@ -97,7 +109,7 @@ public class Job4ClientService {
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("일 해결 신청 알림!").body(
             fcmUtil.askRequest2WorkerMsg(worker.getNickname(), job.getTitle())).build());
     }
-
+    // 5) 일 수락 혹은 거절
     @Transactional
     public void yesOrNo2RequestOfWorker(YesOrNo2WorkersRequest request) {
         Member owner = userAccessUtil.getMember();
@@ -109,7 +121,7 @@ public class Job4ClientService {
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("일 시작 알림!").body(
             fcmUtil.requestAcceptedBody(owner.getNickname(), worker.getNickname(), job.getTitle())).build());
     }
-    // 일 철회 요청
+    // 6) NO Show 사용자를 위해 일 철회 요청
     @Transactional
     public void requestWithdrawal(Job2ClientRequest request) {
         Member owner = userAccessUtil.getMember();
@@ -123,5 +135,13 @@ public class Job4ClientService {
         jobUtil.scheduledSleepMatching2Cancel(matching);
         fcmUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("혹시 잠수 타셨나요??").body(
             fcmUtil.requestAcceptedBody(owner.getNickname(), worker.getNickname(), job.getTitle())).build());
+    }
+    // 7) 결제 내역으로 일 찾기
+    public Job findByTid(String tid) {
+        return jobRepository.findByTid(tid).orElseThrow(() -> new GlobalException(ErrorCode.INVALID_TITLE));
+    }
+    // 8) 일 하나 상세 보기
+    public JobResponse getJobDetail(long jobId) {
+        return  null;
     }
 }

--- a/src/main/java/spot/spot/global/response/handler/GlobalExceptionHandler.java
+++ b/src/main/java/spot/spot/global/response/handler/GlobalExceptionHandler.java
@@ -31,7 +31,7 @@ public class GlobalExceptionHandler {
     // 예기치 못한 에러 발생 시 (일단 에러 내용이 front 한테도 보이게 뒀습니다. 배포할 때 고치겠습니다.
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ResultResponse<Object>> handleUnExpectException (Exception e) {
-        ColorLogger.red("예상치 못한 에러: {}",e);
+        ColorLogger.red("예상치 못한 에러: ",e);
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .headers(jsonHeaders)

--- a/src/main/java/spot/spot/global/response/handler/GlobalResponseHandler.java
+++ b/src/main/java/spot/spot/global/response/handler/GlobalResponseHandler.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
@@ -46,6 +47,7 @@ public class GlobalResponseHandler implements ResponseBodyAdvice<Object> {
         }
         // 만약 String이면 예외 발생
         if (body instanceof String) {throw new GlobalException(ErrorCode.NOT_ALLOW_STRING);}
+        if( body instanceof ResultResponse<?> ) return body;
         return ResultResponse.success(body);
     }
 }


### PR DESCRIPTION
# 💡 Issue
- close #91 
- fix #83 

# 🌱 Key changes
- [x] 중복된 API 없애기 

# ✅ To Reviewers
일 하나 확인하기랑 일 실시간 상세 페이지랑 내용이 같은데, API를 굳이 두 개 둘 필요가 없을 것 같아서, 일 실시간 상세 페이지용 API 지웁니다.

일 하나 상세 메타 데이터가 필요할 경우 
- #83
을 활용하시기 바랍니다. 


# 📸 스크린샷
단순한 삭제 PR이라 스크린샷 생략 
