### PR TITLE
fix: payReadyResponseDto payHistory 필드 삭제

### DIFF
--- a/src/main/java/spot/spot/domain/pay/entity/PayHistory.java
+++ b/src/main/java/spot/spot/domain/pay/entity/PayHistory.java
@@ -26,7 +26,8 @@ public class PayHistory {
     @Setter
     private String worker;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_id")
     private Job job;
 
     @Setter

--- a/src/main/java/spot/spot/domain/pay/entity/dto/response/PayReadyResponseDto.java
+++ b/src/main/java/spot/spot/domain/pay/entity/dto/response/PayReadyResponseDto.java
@@ -13,18 +13,15 @@ public record PayReadyResponseDto(
         @Schema(description = "카카오페이 결제 Mobile url", example = "https://online-payment.kakaopay.com/mockup/bridge/mobile-web/pg/one-time/payment/279935155306a3f71f3b5019d78c5d90b009bebd85bd2493023a8ed73de0826c")
         String redirectMobileUrl,
         @Schema(description = "결제 상품 id", example = "T1231ADFV2424")
-        String tid,
-        @Schema(description = "결제내역", example = "PayHistory.class")
-        PayHistory payHistory
+        String tid
 
 ) {
 
-        public static PayReadyResponseDto of(PayReadyResponse payReadyResponse, PayHistory payHistory) {
+        public static PayReadyResponseDto of(PayReadyResponse payReadyResponse) {
                 return  PayReadyResponseDto.builder()
                         .redirectPCUrl(payReadyResponse.getNext_redirect_pc_url())
                         .redirectMobileUrl(payReadyResponse.getNext_redirect_mobile_url())
                         .tid(payReadyResponse.getTid())
-                        .payHistory(payHistory)
                         .build();
         }
 
@@ -33,7 +30,6 @@ public record PayReadyResponseDto(
                         .redirectPCUrl(redirectPcUrl)
                         .redirectMobileUrl(redirectMobileUrl)
                         .tid(tid)
-                        .payHistory(payHistory)
                         .build();
         }
 }

--- a/src/main/java/spot/spot/domain/pay/service/PayService.java
+++ b/src/main/java/spot/spot/domain/pay/service/PayService.java
@@ -64,9 +64,9 @@ public class PayService {
 
         ///결제 내역 기록 및 결제 준비
         HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(parameters, getHeaders());
-        PayHistory payHistory = savePayHistory(memberNickname, amount, point, job);
+        savePayHistory(memberNickname, amount, point, job);
         PayReadyResponse payReadyResponse = payAPIRequestService.payAPIRequest("ready", requestEntity, PayReadyResponse.class);
-        return PayReadyResponseDto.of(payReadyResponse, payHistory);
+        return PayReadyResponseDto.of(payReadyResponse);
     }
 
     //결제 승인(결제)
@@ -145,6 +145,7 @@ public class PayService {
     }
 
     //일 등록 시 payHistory에 저장
+    @Transactional
     protected PayHistory savePayHistory(String depositor, int payAmount, int point, Job job) {
         PayHistory payHistory = PayHistory.builder()
                 .payAmount(payAmount)


### PR DESCRIPTION
# 💡 Issue
- #159 
# 🌱 Key changes
- [x] payReadyResponseDto 에서 payHistory 삭제

# ✅ To Reviewers
불필요한 job update 쿼리가 나가서 matchings의 lazyLoading에서 문제가 발생하여 필드를 삭제하였습니다.
# 📸 스크린샷
