### PR TITLE
fix: pay_history의 job을 일대일에서 다대일로 수정

### DIFF
--- a/src/main/java/spot/spot/domain/pay/entity/PayHistory.java
+++ b/src/main/java/spot/spot/domain/pay/entity/PayHistory.java
@@ -26,8 +26,8 @@ public class PayHistory {
     @Setter
     private String worker;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "job_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_id", nullable = false)
     private Job job;
 
     @Setter


### PR DESCRIPTION
# 💡 Issue
- #183 
# 🌱 Key changes
- [x] pay_history의 job 필드를 일대일에서 다대일로 변경

# ✅ To Reviewers
데이터 삽입하다가 job과 payHistory가 일대일이 아닌 다대일매핑이 맞아서 수정했습니다.
# 📸 스크린샷
