### PR TITLE
RESOLVED: WorkerQueryMapper Img Mapping

### DIFF
--- a/src/main/java/spot/spot/domain/job/query/mapper/WorkerQueryMapper.java
+++ b/src/main/java/spot/spot/domain/job/query/mapper/WorkerQueryMapper.java
@@ -13,6 +13,7 @@ import spot.spot.domain.job.query.util._docs.DistanceCalculateUtilDocs;
 public interface WorkerQueryMapper {
 
     @Mapping(target = "dist", ignore = true)
+    @Mapping(target = "picture", source = "img")
     NearByJobResponse toNearByJobResponse(Job job);
 
     default List<NearByJobResponse> toNearByJobResponseList(List<Job> jobs, Location location) {


### PR DESCRIPTION
# 💡 Issue
- fix #194 
- resolve #82 

# 🌱 Key changes
- [x] 1. dto는 picture이고 entity는 img라는 이름을 써서 서로 Mapping이 안되었습니다.  이 이슈 해결 했습니다.

# ✅ To Reviewers

# 📸 스크린샷
![image](https://github.com/user-attachments/assets/3599b6af-bab9-401b-9585-43a54b066261)

