### PR TITLE
FIX: 일 상세 확인에 `내가 일의 주인 인지` 확인 하는 컬럼 추가

### DIFF
--- a/src/main/java/spot/spot/domain/job/query/dto/response/JobDetailResponse.java
+++ b/src/main/java/spot/spot/domain/job/query/dto/response/JobDetailResponse.java
@@ -34,6 +34,8 @@ public class JobDetailResponse{
     private String nickname;
     @Schema(description = "의뢰인 프로필 사진")
     private String clientImg;
-    @Schema(description = "내가 신청한 일인가")
+    @Schema(description = "요청한 사용자와 일의 관계")
     private MatchingStatus myStatus;
+    @Schema(description = "내가 이 일의 주인인가")
+    private boolean isOwner;
 }

--- a/src/main/java/spot/spot/domain/job/query/repository/dsl/SearchingOneQueryDsl.java
+++ b/src/main/java/spot/spot/domain/job/query/repository/dsl/SearchingOneQueryDsl.java
@@ -1,6 +1,7 @@
 package spot.spot.domain.job.query.repository.dsl;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -51,7 +52,11 @@ public class SearchingOneQueryDsl {
                 member.id,
                 member.nickname,
                 member.img,
-                myMatching.status
+                myMatching.status,
+                new CaseBuilder()
+                    .when(member.id.eq(memberId)) // member.id가 memberId와 같으면 true
+                    .then(true)
+                    .otherwise(false)
             ))
             .from(job)
             .join(matching).on(job.id.eq(matching.job.id))


### PR DESCRIPTION
# 💡 Issue
- close #201 

# 🌱 Key changes
- [ ] 1. 서브 쿼리가 아닌, `case when` 문을 구현하는 CaseBuilder를 써서 O(1) 시간 안에 누가 일의 주인인지를 확인 가능하게 했습니다.

# ✅ To Reviewers
- 이러한 행위가 실제로 더 빠른지 확인하는 테스팅이 필요

# 📸 스크린샷
