### PR TITLE
FIX: NOTIFICATION 알림 리스트 Type-case 오류 해결

### DIFF
--- a/src/main/java/spot/spot/domain/notification/query/repository/SearchingNotificationListDsl.java
+++ b/src/main/java/spot/spot/domain/notification/query/repository/SearchingNotificationListDsl.java
@@ -25,14 +25,15 @@ public class SearchingNotificationListDsl {
     public Slice<NotificationResponse> getMyNotificationList(long memberId, Pageable pageable) {
         List<NotificationResponse> list
             = queryFactory
-            .select(Projections.constructor(NotificationResponse.class,
+            .select(Projections.fields(NotificationResponse.class,
                 notification.id,
                 notification.createdAt,
                 notification.content,
-                notification.member.id.as("senderId"),
+                notification.member.id,
                 member.nickname,
-                member.img
-                ))
+                member.img,
+                notification.type
+            ))
             .from(notification)
             .join(member)
             .on(member.id.eq(notification.recevierId))


### PR DESCRIPTION

# 💡 Issue
- fix: #203 

# 🌱 Key changes
- [x] 1. queryDSL 수정

# ✅ To Reviewers
record는 생성자 이용 못함 따라서, 필드 주입식으로 변경.
record는 불변 객체라서 암시적인 생성자만 있을 뿐 명시적 생성자가 없다고 함. 더 알아볼 시간이 없어서 급한대로 field 주입식 QueryDsl로 전환 
# 📸 스크린샷
