### PR TITLE
FEAT: mySQL 방언, 공간 데이터 활용 없이 순수 쿼리 최적화

### DIFF
--- a/src/main/java/spot/spot/domain/job/query/controller/_docs/WorkerQueryDocs.java
+++ b/src/main/java/spot/spot/domain/job/query/controller/_docs/WorkerQueryDocs.java
@@ -22,9 +22,9 @@ public interface WorkerQueryDocs {
         """)
     @GetMapping
     public Slice<NearByJobResponse> nearByJobs(
-        @RequestParam Double lat,
-        @RequestParam Double lng,
-        @RequestParam Integer zoom,
+        @RequestParam(required = false) Double lat,
+        @RequestParam(required = false) Double lng,
+        @RequestParam(required = false, defaultValue = "21") Integer zoom,
         Pageable pageable
     );
 

--- a/src/main/java/spot/spot/domain/job/query/dto/response/NearByJobResponse.java
+++ b/src/main/java/spot/spot/domain/job/query/dto/response/NearByJobResponse.java
@@ -1,11 +1,13 @@
 package spot.spot.domain.job.query.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder(toBuilder = true)  // 기존 객체 복사 (변수의 값도 같이 복사), 원하는 값만 변경 가능!
+@Builder(toBuilder = true)
+@AllArgsConstructor
 public class NearByJobResponse {
     @Schema(description = "일의 고유 아이디")
     private long id;

--- a/src/main/java/spot/spot/domain/job/query/repository/dsl/_docs/SearchingListQueryDocs.java
+++ b/src/main/java/spot/spot/domain/job/query/repository/dsl/_docs/SearchingListQueryDocs.java
@@ -16,11 +16,12 @@ import spot.spot.domain.job.command.entity.MatchingStatus;
 import spot.spot.domain.job.command.entity.QJob;
 import spot.spot.domain.job.command.entity.QMatching;
 import spot.spot.domain.job.query.dto.response.CertificationImgResponse;
+import spot.spot.domain.job.query.dto.response.NearByJobResponse;
 import spot.spot.domain.member.entity.Worker;
 
 public interface SearchingListQueryDocs {
     // QueryDSL로 해결사 근처 일 리스트 찾기 - 지도에 띄우는 걸 가정한 반경 사용자 좌표 변환
-    public Slice<Job> findNearByJobsWithQueryDSL(double lat, double lng, double dist, Pageable pageable);
+    public Slice<NearByJobResponse> findNearByJobsWithQueryDSL(double lat, double lng, double dist, Pageable pageable);
     // 일에 신청한 해결사 리스트 반환
     public Slice<Worker> findWorkersByJobId(Long jobId, Pageable pageable);
     // 일 주인이 봤을 때 일 의뢰 현황 리스트 반환

--- a/src/main/java/spot/spot/domain/job/query/service/WorkerQueryService.java
+++ b/src/main/java/spot/spot/domain/job/query/service/WorkerQueryService.java
@@ -34,6 +34,7 @@ public class WorkerQueryService implements WorkerQueryServiceDocs {
         Member member = userAccessUtil.getMember();
         lat = lat == null? member.getLat() : lat;
         lng = lng == null? member.getLng(): lng;
+        log.info("{}, {}", lat, lng);
         return jobSearchQueryDSLService.findNearByJobs(lat, lng, zoom, pageable);
     }
 

--- a/src/main/java/spot/spot/domain/job/query/util/searching/SearchingJobJPQLQueryUtil.java
+++ b/src/main/java/spot/spot/domain/job/query/util/searching/SearchingJobJPQLQueryUtil.java
@@ -1,15 +1,10 @@
 package spot.spot.domain.job.query.util.searching;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
-import spot.spot.domain.job.command.dto.Location;
 import spot.spot.domain.job.query.dto.response.NearByJobResponse;
-import spot.spot.domain.job.command.entity.Job;
-import spot.spot.domain.job.query.mapper.WorkerQueryMapper;
 import spot.spot.domain.job.query.repository.jpa.JobRepository;
 import spot.spot.domain.job.query.util._docs.SearchingJobQueryUtil;
 import spot.spot.domain.job.query.util.DistanceCalculateUtil;
@@ -20,14 +15,10 @@ public class SearchingJobJPQLQueryUtil implements SearchingJobQueryUtil {
 
     private final JobRepository jobRepository;
     private final DistanceCalculateUtil distanceCalculateUtil;
-    private final WorkerQueryMapper workerQueryMapper;
 
     @Override
     public Slice<NearByJobResponse> findNearByJobs(double lat, double lng, int zoom, Pageable pageable) {
         double dist = distanceCalculateUtil.convertZoomToRadius(zoom);
-        Slice<Job> jobs = jobRepository.findNearByJobWithJPQL(lat, lng,dist, pageable);
-        List<NearByJobResponse> responseList = workerQueryMapper
-            .toNearByJobResponseList(jobs.getContent(), Location.builder().lat(lat).lng(lng).build());
-        return new SliceImpl<>(responseList, pageable, jobs.hasNext());
+        return jobRepository.findNearByJobWithJPQL(lat,lng,zoom,pageable);
     }
 }

--- a/src/main/java/spot/spot/domain/job/query/util/searching/SearchingJobNativeQueryUtil.java
+++ b/src/main/java/spot/spot/domain/job/query/util/searching/SearchingJobNativeQueryUtil.java
@@ -6,10 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
-import spot.spot.domain.job.command.dto.Location;
 import spot.spot.domain.job.query.dto.response.NearByJobResponse;
-import spot.spot.domain.job.command.entity.Job;
-import spot.spot.domain.job.query.mapper.WorkerQueryMapper;
 import spot.spot.domain.job.query.repository.jpa.JobRepository;
 import spot.spot.domain.job.query.util._docs.SearchingJobQueryUtil;
 import spot.spot.domain.job.query.util.DistanceCalculateUtil;
@@ -20,23 +17,18 @@ public class SearchingJobNativeQueryUtil implements SearchingJobQueryUtil {
 
     private final JobRepository jobRepository;
     private final DistanceCalculateUtil distanceCalculateUtil;
-    private final WorkerQueryMapper workerQueryMapper;
 
     @Override
     public Slice<NearByJobResponse> findNearByJobs(double lat, double lng, int zoom, Pageable pageable) {
         double dist = distanceCalculateUtil.convertZoomToRadius(zoom);
         int offset = pageable.getPageNumber() * pageable.getPageSize();
-        List<Job> jobs = jobRepository.findNearByJobWithNativeQuery(lat, lng, dist,
+        List<NearByJobResponse> jobs = jobRepository.findNearByJobWithNativeQuery(lat, lng, dist,
             pageable.getPageSize() +1, offset);
-
         boolean hasNext = jobs.size() > pageable.getPageSize();
         if(hasNext) {
             jobs = jobs.subList(0, pageable.getPageSize());
         }
-
-        List<NearByJobResponse> responseList = workerQueryMapper
-            .toNearByJobResponseList(jobs, Location.builder().lat(lat).lng(lng).build());
-        return new SliceImpl<>(responseList, pageable, hasNext);
+        return new SliceImpl<>(jobs, pageable, hasNext);
 
     }
 }

--- a/src/main/java/spot/spot/domain/job/query/util/searching/SearchingJobQueryDSLUtil.java
+++ b/src/main/java/spot/spot/domain/job/query/util/searching/SearchingJobQueryDSLUtil.java
@@ -1,15 +1,10 @@
 package spot.spot.domain.job.query.util.searching;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
-import spot.spot.domain.job.command.dto.Location;
 import spot.spot.domain.job.query.dto.response.NearByJobResponse;
-import spot.spot.domain.job.command.entity.Job;
-import spot.spot.domain.job.query.mapper.WorkerQueryMapper;
 import spot.spot.domain.job.query.repository.dsl.SearchingListQueryDsl;
 import spot.spot.domain.job.query.util._docs.SearchingJobQueryUtil;
 import spot.spot.domain.job.query.util.DistanceCalculateUtil;
@@ -20,14 +15,10 @@ public class SearchingJobQueryDSLUtil implements SearchingJobQueryUtil {
 
     private final SearchingListQueryDsl jobQueryDsl;
     private final DistanceCalculateUtil distanceCalculateUtil;
-    private final WorkerQueryMapper workerQueryMapper;
 
     @Override
     public Slice<NearByJobResponse> findNearByJobs(double lat, double lng, int zoom, Pageable pageable) {
         double dist = distanceCalculateUtil.convertZoomToRadius(zoom);
-        Slice<Job> jobs = jobQueryDsl.findNearByJobsWithQueryDSL(lat, lng, dist, pageable);
-        List<NearByJobResponse> responseList = workerQueryMapper
-            .toNearByJobResponseList(jobs.getContent(), Location.builder().lat(lat).lng(lng).build());
-        return new SliceImpl<>(responseList, pageable, jobs.hasNext());
+        return jobQueryDsl.findNearByJobsWithQueryDSL(lat,lng, dist, pageable);
     }
 }

--- a/src/main/java/spot/spot/domain/job/v1/query/controller/WorkerQueryControllerV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/controller/WorkerQueryControllerV1.java
@@ -7,16 +7,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import spot.spot.domain.job.v1.query.controller._docs.WorkerQueryVersion1Docs;
+import spot.spot.domain.job.v1.query.controller._docs.WorkerQueryDocsV1;
 import spot.spot.domain.job.query.dto.response.NearByJobResponse;
-import spot.spot.domain.job.v1.query.service.WorkerQueryVersion1Service;
+import spot.spot.domain.job.v1.query.service.WorkerQueryServiceV1;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/job/v1")
-public class WorkerQueryVersion1Controller implements WorkerQueryVersion1Docs {
+public class WorkerQueryControllerV1 implements WorkerQueryDocsV1 {
 
-    private final WorkerQueryVersion1Service workerQueryVersion1Service;
+    private final WorkerQueryServiceV1 workerQueryServiceV1;
 
     @GetMapping("/search/jpql")
     public Slice<NearByJobResponse> nearByJobWithJPQL(
@@ -24,7 +24,7 @@ public class WorkerQueryVersion1Controller implements WorkerQueryVersion1Docs {
         @RequestParam(required = false) Double lng,
         @RequestParam(required = false, defaultValue = "21") Integer zoom,
         Pageable pageable) {
-        return workerQueryVersion1Service.getNearByJobListWithJPQL(lat, lng, zoom, pageable);
+        return workerQueryServiceV1.getNearByJobListWithJPQL(lat, lng, zoom, pageable);
     }
 
     @GetMapping("/search/native-query")
@@ -33,7 +33,7 @@ public class WorkerQueryVersion1Controller implements WorkerQueryVersion1Docs {
         @RequestParam(required = false) Double lng,
         @RequestParam(required = false, defaultValue = "21") Integer zoom,
         Pageable pageable) {
-        return workerQueryVersion1Service.getNearByJobListWithNativeQuery(lat, lng, zoom, pageable);
+        return workerQueryServiceV1.getNearByJobListWithNativeQuery(lat, lng, zoom, pageable);
     }
 
     @GetMapping("/search/query-dsl")
@@ -42,6 +42,6 @@ public class WorkerQueryVersion1Controller implements WorkerQueryVersion1Docs {
         @RequestParam(required = false) Double lng,
         @RequestParam(required = false, defaultValue = "21") Integer zoom,
         Pageable pageable) {
-        return null;
+        return workerQueryServiceV1.getNearByJobListWithQueryDsl(lat, lng, zoom, pageable);
     }
 }

--- a/src/main/java/spot/spot/domain/job/v1/query/controller/_docs/WorkerQueryDocsV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/controller/_docs/WorkerQueryDocsV1.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import spot.spot.domain.job.query.dto.response.NearByJobResponse;
 
 @Tag(name= "가. (V1) WORKER QUERY API ", description = "<br/> 해결사 R API (첫 구현)")
-public interface WorkerQueryVersion1Docs {
+public interface WorkerQueryDocsV1 {
 
     @Operation(summary = "JPQL로 DB 쿼리로 거리 계산 후 리스트 출력 (default 위도 경도 현 사용자의 위도 경도)")
     public Slice<NearByJobResponse> nearByJobWithJPQL (

--- a/src/main/java/spot/spot/domain/job/v1/query/mapper/WorkerQueryMapperV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/mapper/WorkerQueryMapperV1.java
@@ -1,4 +1,5 @@
-package spot.spot.domain.job.query.mapper;
+package spot.spot.domain.job.v1.query.mapper;
+
 
 import java.util.List;
 import org.mapstruct.Mapper;
@@ -9,8 +10,9 @@ import spot.spot.domain.job.command.entity.Job;
 import spot.spot.domain.job.query.dto.response.NearByJobResponse;
 import spot.spot.domain.job.query.util._docs.DistanceCalculateUtilDocs;
 
+@Deprecated
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public interface WorkerQueryMapper {
+public interface WorkerQueryMapperV1 {
 
     @Mapping(target = "dist", ignore = true)
     @Mapping(target = "picture", source = "img")

--- a/src/main/java/spot/spot/domain/job/v1/query/repository/dsl/SearchingListQueryDslV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/repository/dsl/SearchingListQueryDslV1.java
@@ -29,15 +29,12 @@ public class SearchingListQueryDslV1 {
             "(6371 * acos(cos(radians({0})) * cos(radians({1})) * cos(radians({2}) - radians({3})) + sin(radians({4})) * sin(radians({5}))))",
             lat, job.lat, job.lng, lng, lat, job.lat
         );
-        final  double rangeFilter = dist / (111.045 * Math.cos(Math.toRadians(lat)));
 
         List<Job> jobs = queryFactory
             .select(job)
             .from(job)
             .where(
                 job.startedAt.isNull(),
-                job.lat.between(lat - (dist / 111.045), lat + (dist / 111.045)),
-                job.lng.between(lng - rangeFilter, lng + rangeFilter),
                 distanceExpression.lt(dist)
             )
             .orderBy(distanceExpression.asc())

--- a/src/main/java/spot/spot/domain/job/v1/query/repository/dsl/SearchingListQueryDslV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/repository/dsl/SearchingListQueryDslV1.java
@@ -1,0 +1,60 @@
+package spot.spot.domain.job.v1.query.repository.dsl;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+import spot.spot.domain.job.command.entity.Job;
+import spot.spot.domain.job.command.entity.QJob;
+
+@Repository
+@Deprecated
+@RequiredArgsConstructor
+public class SearchingListQueryDslV1 {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Slice<Job> findNearByJobsWithQueryDSLVersion1(double lat, double lng, double dist, Pageable pageable) {
+        QJob job = QJob.job;
+
+        // Haversine을 이용한 거리 계산
+        // Expressions.numberTemplate = queryDsl에서 숫자 계산에 쓰는 양식 -> sql 수식을 사용하면서도 Java 코드로서 사용 가능함.
+        // NumberExpression<Double> = double 값을 반환함을 명시
+        NumberExpression<Double> distanceExpression = Expressions.numberTemplate(Double.class,
+            "(6371 * acos(cos(radians({0})) * cos(radians({1})) * cos(radians({2}) - radians({3})) + sin(radians({4})) * sin(radians({5}))))",
+            lat, job.lat, job.lng, lng, lat, job.lat
+        );
+        final  double rangeFilter = dist / (111.045 * Math.cos(Math.toRadians(lat)));
+
+        List<Job> jobs = queryFactory
+            .select(job)
+            .from(job)
+            .where(
+                job.startedAt.isNull(),
+                job.lat.between(lat - (dist / 111.045), lat + (dist / 111.045)),
+                job.lng.between(lng - rangeFilter, lng + rangeFilter),
+                distanceExpression.lt(dist)
+            )
+            .orderBy(distanceExpression.asc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize() + 1) // 한 개 더 확인해서 다음 페이지가 있는지 확인
+            .fetch();
+
+        // 다음 페이지가 있는지 계산
+        // QueryDsl은 page 객체는 자동 지원하지만, Slice 객체는 지원하지 않음.
+        // 우리는 APP 용 무한 스크롤을 구현해야함으로, Slice를 사용해야함.
+        // N+1개가 불러와진다. -> 다음이 존재한다. N개 이하로 불러와진다. -> 다음 페이지가 없다.
+        boolean hasNext = jobs.size() > pageable.getPageSize();
+        if(hasNext) {
+            // 다음 페이지가 있으면 찾은 게 11개니 10개로 짤라서 반환
+            jobs = jobs.subList(0, pageable.getPageSize());
+        }
+        // Slice 인터페이스의 구현체 (JPA에서 제공). <내용물, pageable 객체, 다음이 있는지 여부>를 주면 된다.
+        return new SliceImpl<>(jobs, pageable, hasNext);
+    }
+}

--- a/src/main/java/spot/spot/domain/job/v1/query/repository/jpa/JobRepositoryV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/repository/jpa/JobRepositoryV1.java
@@ -1,7 +1,6 @@
-package spot.spot.domain.job.query.repository.jpa;
+package spot.spot.domain.job.v1.query.repository.jpa;
 
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,31 +8,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import spot.spot.domain.job.command.entity.Job;
-import spot.spot.domain.job.query.dto.response.NearByJobResponse;
 
 @Repository
-public interface JobRepository extends JpaRepository<Job, Long> {
-
+@Deprecated
+public interface JobRepositoryV1 extends JpaRepository<Job, Long> {
     @Query("""
-    SELECT new spot.spot.domain.job.query.dto.response.NearByJobResponse(
-        j.id, 
-        j.title, 
-        j.content, 
-        j.img, 
-        j.lat, 
-        j.lng, 
-        j.money, 
-        (6371 * acos(
-               cos(radians(:lat)) * cos(radians(j.lat)) *
-               cos(radians(j.lng) - radians(:lng)) +
-               sin(radians(:lat)) * sin(radians(j.lat))
-           )),
-        j.tid
-    ) 
-    FROM Job j
+    SELECT j FROM Job j
     WHERE j.startedAt IS NULL
       AND j.lat BETWEEN :lat - (:dist / 111.045) AND :lat + (:dist / 111.045)
-      AND j.lng BETWEEN :lng - (:dist / (111.045 * cos(radians(:lat)))) 
+      AND j.lng BETWEEN :lng - (:dist / (111.045 * cos(radians(:lat))))
                    AND :lng + (:dist / (111.045 * cos(radians(:lat))))
       AND (6371 * acos(
                cos(radians(:lat)) * cos(radians(j.lat)) *
@@ -46,7 +29,7 @@ public interface JobRepository extends JpaRepository<Job, Long> {
                 sin(radians(:lat)) * sin(radians(j.lat))
             )) ASC
     """)
-    Slice<NearByJobResponse> findNearByJobWithJPQL(
+    Slice<Job> findNearByJobWithJPQL(
         @Param("lat") double lat,
         @Param("lng") double lng,
         @Param("dist") double dist,
@@ -54,19 +37,7 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     );
 
     @Query(value = """
-    SELECT 
-        j.id AS id,
-        j.title AS title,
-        j.content AS content,
-        j.img AS picture,
-        j.lat AS lat,
-        j.lng AS lng,
-        j.money AS money,
-        ST_Distance_Sphere(
-            point(j.lng, j.lat),
-            point(:lng, :lat)
-        ) / 1000 AS dist, -- 미터를 km 단위로 변환
-        j.tid AS tid
+    SELECT j.*
     FROM job j
     WHERE j.started_at IS NULL
       AND j.lat BETWEEN :lat - (:dist / 111.045) 
@@ -76,20 +47,18 @@ public interface JobRepository extends JpaRepository<Job, Long> {
       AND ST_Distance_Sphere(
                point(j.lng, j.lat),
                point(:lng, :lat)
-           ) / 1000 < :dist -- km 단위 거리 비교
+           ) / 1000 < :dist -- 미터 단위이므로 km로 변환
     ORDER BY ST_Distance_Sphere(
                  point(j.lng, j.lat),
                  point(:lng, :lat)
              ) ASC
     LIMIT :pageSize OFFSET :offset
     """, nativeQuery = true)
-    List<NearByJobResponse> findNearByJobWithNativeQuery(
+    List<Job> findNearByJobWithNativeQuery(
         @Param("lat") double lat,
         @Param("lng") double lng,
         @Param("dist") double dist,
         @Param("pageSize") int pageSize,
         @Param("offset") int offset
     );
-
-    Optional<Job> findByTid(String tid);
 }

--- a/src/main/java/spot/spot/domain/job/v1/query/repository/jpa/JobRepositoryV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/repository/jpa/JobRepositoryV1.java
@@ -15,9 +15,6 @@ public interface JobRepositoryV1 extends JpaRepository<Job, Long> {
     @Query("""
     SELECT j FROM Job j
     WHERE j.startedAt IS NULL
-      AND j.lat BETWEEN :lat - (:dist / 111.045) AND :lat + (:dist / 111.045)
-      AND j.lng BETWEEN :lng - (:dist / (111.045 * cos(radians(:lat))))
-                   AND :lng + (:dist / (111.045 * cos(radians(:lat))))
       AND (6371 * acos(
                cos(radians(:lat)) * cos(radians(j.lat)) *
                cos(radians(j.lng) - radians(:lng)) +
@@ -40,10 +37,6 @@ public interface JobRepositoryV1 extends JpaRepository<Job, Long> {
     SELECT j.*
     FROM job j
     WHERE j.started_at IS NULL
-      AND j.lat BETWEEN :lat - (:dist / 111.045) 
-                   AND :lat + (:dist / 111.045)
-      AND j.lng BETWEEN :lng - (:dist / (111.045 * cos(radians(:lat)))) 
-                   AND :lng + (:dist / (111.045 * cos(radians(:lat))))
       AND ST_Distance_Sphere(
                point(j.lng, j.lat),
                point(:lng, :lat)

--- a/src/main/java/spot/spot/domain/job/v1/query/service/SearchingJobJpqlQueryUtilVV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/service/SearchingJobJpqlQueryUtilVV1.java
@@ -1,0 +1,33 @@
+package spot.spot.domain.job.v1.query.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Service;
+import spot.spot.domain.job.command.dto.Location;
+import spot.spot.domain.job.command.entity.Job;
+import spot.spot.domain.job.query.dto.response.NearByJobResponse;
+import spot.spot.domain.job.query.util.DistanceCalculateUtil;
+import spot.spot.domain.job.v1.query.mapper.WorkerQueryMapperV1;
+import spot.spot.domain.job.v1.query.repository.jpa.JobRepositoryV1;
+import spot.spot.domain.job.v1.query.service._docs.SearchingJobQueryVersionUtilV1;
+
+@Service
+@Deprecated
+@RequiredArgsConstructor
+public class SearchingJobJpqlQueryUtilVV1 implements SearchingJobQueryVersionUtilV1 {
+    private final JobRepositoryV1 jobRepositoryV1;
+    private final DistanceCalculateUtil distanceCalculateUtil;
+    private final WorkerQueryMapperV1 workerQueryMapperV1;
+
+    @Override
+    public Slice<NearByJobResponse> findNearByJobs(double lat, double lng, int zoom, Pageable pageable) {
+        double dist = distanceCalculateUtil.convertZoomToRadius(zoom);
+        Slice<Job> jobs = jobRepositoryV1.findNearByJobWithJPQL(lat, lng,dist, pageable);
+        List<NearByJobResponse> responseList = workerQueryMapperV1
+            .toNearByJobResponseList(jobs.getContent(), Location.builder().lat(lat).lng(lng).build());
+        return new SliceImpl<>(responseList, pageable, jobs.hasNext());
+    }
+}

--- a/src/main/java/spot/spot/domain/job/v1/query/service/SearchingJobNativeQueryUtilVV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/service/SearchingJobNativeQueryUtilVV1.java
@@ -1,0 +1,42 @@
+package spot.spot.domain.job.v1.query.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Service;
+import spot.spot.domain.job.command.dto.Location;
+import spot.spot.domain.job.command.entity.Job;
+import spot.spot.domain.job.query.dto.response.NearByJobResponse;
+import spot.spot.domain.job.query.util.DistanceCalculateUtil;
+import spot.spot.domain.job.v1.query.mapper.WorkerQueryMapperV1;
+import spot.spot.domain.job.v1.query.repository.jpa.JobRepositoryV1;
+import spot.spot.domain.job.v1.query.service._docs.SearchingJobQueryVersionUtilV1;
+
+
+@Service
+@Deprecated
+@RequiredArgsConstructor
+public class SearchingJobNativeQueryUtilVV1 implements SearchingJobQueryVersionUtilV1 {
+    private final JobRepositoryV1 jobRepositoryV1;
+    private final DistanceCalculateUtil distanceCalculateUtil;
+    private final WorkerQueryMapperV1 workerQueryMapperV1;
+
+    @Override
+    public Slice<NearByJobResponse> findNearByJobs(double lat, double lng, int zoom, Pageable pageable) {
+        double dist = distanceCalculateUtil.convertZoomToRadius(zoom);
+        int offset = pageable.getPageNumber() * pageable.getPageSize();
+        List<Job> jobs = jobRepositoryV1.findNearByJobWithNativeQuery(lat, lng, dist,
+            pageable.getPageSize() + 1, offset);
+
+        boolean hasNext = jobs.size() > pageable.getPageSize();
+        if (hasNext) {
+            jobs = jobs.subList(0, pageable.getPageSize());
+        }
+
+        List<NearByJobResponse> responseList = workerQueryMapperV1
+            .toNearByJobResponseList(jobs, Location.builder().lat(lat).lng(lng).build());
+        return new SliceImpl<>(responseList, pageable, hasNext);
+    }
+}

--- a/src/main/java/spot/spot/domain/job/v1/query/service/SearchingJobQueryDslVersionUtilVV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/service/SearchingJobQueryDslVersionUtilVV1.java
@@ -1,0 +1,34 @@
+package spot.spot.domain.job.v1.query.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Service;
+import spot.spot.domain.job.command.dto.Location;
+import spot.spot.domain.job.command.entity.Job;
+import spot.spot.domain.job.query.dto.response.NearByJobResponse;
+import spot.spot.domain.job.query.util.DistanceCalculateUtil;
+import spot.spot.domain.job.v1.query.mapper.WorkerQueryMapperV1;
+import spot.spot.domain.job.v1.query.repository.dsl.SearchingListQueryDslV1;
+import spot.spot.domain.job.v1.query.service._docs.SearchingJobQueryVersionUtilV1;
+
+@Service
+@Deprecated
+@RequiredArgsConstructor
+public class SearchingJobQueryDslVersionUtilVV1 implements SearchingJobQueryVersionUtilV1 {
+
+    private final SearchingListQueryDslV1 jobQueryDsl;
+    private final DistanceCalculateUtil distanceCalculateUtil;
+    private final WorkerQueryMapperV1 workerQueryMapperV1;
+
+    @Override
+    public Slice<NearByJobResponse> findNearByJobs(double lat, double lng, int zoom, Pageable pageable) {
+        double dist = distanceCalculateUtil.convertZoomToRadius(zoom);
+        Slice<Job> jobs = jobQueryDsl.findNearByJobsWithQueryDSLVersion1(lat, lng, dist, pageable);
+        List<NearByJobResponse> responseList = workerQueryMapperV1
+            .toNearByJobResponseList(jobs.getContent(), Location.builder().lat(lat).lng(lng).build());
+        return new SliceImpl<>(responseList, pageable, jobs.hasNext());
+    }
+}

--- a/src/main/java/spot/spot/domain/job/v1/query/service/WorkerQueryServiceV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/service/WorkerQueryServiceV1.java
@@ -6,37 +6,35 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import spot.spot.domain.job.query.dto.response.NearByJobResponse;
-import spot.spot.domain.job.query.util._docs.SearchingJobQueryUtil;
-import spot.spot.domain.job.query.util.searching.SearchingJobJPQLQueryUtil;
-import spot.spot.domain.job.query.util.searching.SearchingJobNativeQueryUtil;
-import spot.spot.domain.job.query.util.searching.SearchingJobQueryDSLUtil;
+import spot.spot.domain.job.v1.query.service._docs.SearchingJobQueryVersionUtilV1;
 import spot.spot.domain.member.entity.Member;
 import spot.spot.global.security.util.UserAccessUtil;
 
 @Slf4j
 @Service
+@Deprecated
 @RequiredArgsConstructor
-public class WorkerQueryVersion1Service {
+public class WorkerQueryServiceV1 {
     // Util
     private final UserAccessUtil userAccessUtil;
     // 거리 계산용 3가지
-    private final SearchingJobJPQLQueryUtil searchingJobJPQLQueryUtil;
-    private final SearchingJobNativeQueryUtil searchingJobNativeQueryUtil;
-    private final SearchingJobQueryDSLUtil searchingJobQueryDSLUtil;
+    private final SearchingJobQueryDslVersionUtilVV1 searchingJobQueryDslVersionUtilV1;
+    private final SearchingJobJpqlQueryUtilVV1 searchingJobJpqlQueryUtilV1;
+    private final SearchingJobNativeQueryUtilVV1 searchingJobNativeQueryUtilV1;
 
     public Slice<NearByJobResponse> getNearByJobListWithJPQL(Double lat, Double lng, int zoom, Pageable pageable) {
-        return getNearByJobList(searchingJobJPQLQueryUtil, lat, lng, zoom, pageable);
+        return getNearByJobList(searchingJobJpqlQueryUtilV1, lat, lng, zoom, pageable);
     }
 
     public Slice<NearByJobResponse> getNearByJobListWithNativeQuery(Double lat, Double lng, int zoom, Pageable pageable) {
-        return getNearByJobList(searchingJobNativeQueryUtil, lat, lng, zoom, pageable);
+        return getNearByJobList(searchingJobNativeQueryUtilV1, lat, lng, zoom, pageable);
     }
 
     public Slice<NearByJobResponse> getNearByJobListWithQueryDsl(Double lat, Double lng, int zoom,Pageable pageable) {
-        return getNearByJobList(searchingJobQueryDSLUtil, lat, lng, zoom, pageable);
+        return getNearByJobList(searchingJobQueryDslVersionUtilV1, lat, lng, zoom, pageable);
     }
 
-    private Slice<NearByJobResponse> getNearByJobList(SearchingJobQueryUtil service, Double lat, Double lng, int zoom, Pageable pageable) {
+    private Slice<NearByJobResponse> getNearByJobList(SearchingJobQueryVersionUtilV1 service, Double lat, Double lng, int zoom, Pageable pageable) {
         Member member = userAccessUtil.getMember();
         lat = (lat == null) ? member.getLat() : lat;
         lng = (lng == null) ? member.getLng() : lng;

--- a/src/main/java/spot/spot/domain/job/v1/query/service/_docs/SearchingJobQueryVersionUtilV1.java
+++ b/src/main/java/spot/spot/domain/job/v1/query/service/_docs/SearchingJobQueryVersionUtilV1.java
@@ -1,0 +1,13 @@
+package spot.spot.domain.job.v1.query.service._docs;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import spot.spot.domain.job.query.dto.response.NearByJobResponse;
+
+@Service
+@Deprecated
+public interface SearchingJobQueryVersionUtilV1 {
+    // 1. 근처 사용자 찾아서 페이지 네이션 적용 -> JOB을 찾아서 Mapping 및 dist 계산 로직을 한 번 더 함.
+    Slice<NearByJobResponse> findNearByJobs (double lat, double lng, int zoom, Pageable pageable);
+}


### PR DESCRIPTION
# 💡 Issue
- #214 

# 🌱 Key changes
##  1. 기존 로직에 대한 이해 
![image](https://github.com/user-attachments/assets/1706cded-70b8-462d-a431-310c22569e0d)

-  (1) 위 사진과 같이, 반경 내에 존재하는 객체를 찾기 위해 DB 상 모든 객체를 상대로 **`Haver-sine` 공식 계산**을 하였습니다.  그 결과 실행 계획에서 `scan type`이 **`all`**이 나왔습니다.
- (2) `scan-type: all` 이란 원하는 데이터를 찾기 위해서 테이블 풀 스켄을 때린다는 말입니다. 이는 데이터가 늘어남에 따라 심각한 성능 저하를 초래합니다. 이로 인해, 데이터 부하가 심해질수록 오류율이 늘고, 응답 시간이 30초를 넘어가는 사태가 발생되었습니다.
- (3) B-tree 기반 인덱싱이 소용 없었습니다.
![image](https://github.com/user-attachments/assets/11d768be-fa1e-4c4f-b5fc-fef60670fafa)
위와 같이 index를 적용했으나, B-tree 인덱스는 **값의 크고 작음을 비교한 빠른 조회**에서만 효과를 발휘합니다. 따라서, **Haver-sine**을 활용한 공간 계산에서는 index가 전혀 쓰이지 않았습니다. 
다음은 실행했던 내용의 실행계획입니다. 

```sql
EXPLAIN
SELECT *, (6371 * ACOS(COS(RADIANS(37.5665)) * COS(RADIANS(lat)) * COS(RADIANS(lng) - RADIANS(126.9780)) + SIN(RADIANS(37.5665)) * SIN(RADIANS(lat))))
AS distance
FROM job
WHERE job.started_at != null
AND (6371 * ACOS(COS(RADIANS(37.5665)) * COS(RADIANS(lat)) * COS(RADIANS(lng) - RADIANS(126.9780)) + SIN(RADIANS(37.5665)) * SIN(RADIANS(lat)))) < 5
ORDER BY distance
LIMIT 100;
```
![image](https://github.com/user-attachments/assets/ca188dc3-25d2-4c35-b723-cc603cac4352)
```txt
-> Limit: 100 row(s)  (cost=10612 rows=100) (actual time=147..147 rows=0 loops=1)
    -> Sort: distance, limit input to 100 row(s) per chunk  (cost=10612 rows=97706) (actual time=147..147 rows=0 loops=1)
        -> Filter: ((job.started_at <> NULL) and ((6371 * acos((((<cache>(cos(radians(37.5665))) * cos(radians(job.lat))) * cos((radians(job.lng) - <cache>(radians(126.9780))))) + (<cache>(sin(radians(37.5665))) * sin(radians(job.lat)))))) < 5))  (cost=10612 rows=97706) (actual time=147..147 rows=0 loops=1)
            -> Table scan on job  (cost=10612 rows=97706) (actual time=0.042..138 rows=100000 loops=1)
```
한눈에 봐도 코스트가 높은 것을 볼 수 있습니다. 

## 2. 쿼리 최적화 계획 수립과 실행
개발자 라면, 캐싱이나 SQL 방언을 쓰기 전에, 순수 SQL문을 통한 쿼리 최적화를 할 줄 알아야 한다고 생각했습니다.

- a. gird 기반 필터링 
![image](https://github.com/user-attachments/assets/a81e334d-dfbe-4808-8587-9dda743b7599)
먼저 사용자 위치가 도형의 중심이며, 높이가 10Km, 길이가 10Km 직사각형을 만들어, 그 이외의 값들을 모두 필터링하였습니다.
이를 위해 Between을 활용하였고, 경도와 위도에 보정값을 주어 `Haversine 공식`이 없이도 5Km 근사값으로 필터링할 수 있게 하였습니다. 

- b. Indexing의 활성화
**`between`**을 활용하여 필터링을 하자, **크고 작음을 통한 조회가 가능해져서** index 활용이 활성화 되었습니다. 다음은 실행계획 입니다.
```sql
EXPLAIN
SELECT *, (6371 * ACOS(COS(RADIANS(37.5665)) * COS(RADIANS(lat)) * COS(RADIANS(lng) - RADIANS(126.9780)) + SIN(RADIANS(37.5665)) * SIN(RADIANS(lat))))
AS distance
FROM job
WHERE lat BETWEEN (37.5665 - (5 / 111.045)) AND (37.5665 + (5 / 111.045))
AND lng BETWEEN (126.9780 - (5 / (111.045 * COS(RADIANS(37.5665))))) AND (126.9780 + (5 / (111.045 * COS(RADIANS(37.5665)))))
AND (6371 * ACOS(COS(RADIANS(37.5665)) * COS(RADIANS(lat)) * COS(RADIANS(lng) - RADIANS(126.9780)) + SIN(RADIANS(37.5665)) * SIN(RADIANS(lat)))) < 5
ORDER BY distance
LIMIT 100;
```
![image](https://github.com/user-attachments/assets/59b59607-04c3-43e2-9e74-193b81af3f94)

## 3. 서비스 로직 최적화
기획 요청 사항 중 하나가 사용자와 목적지간의 거리를 KM로 보여준다는 것이 있었습니다. 기존 로직은 다음과 같았습니다.
- 1. 사용자 위치 기반 요청 사항을 만족하는 거리의 일 레코드 전부 긁어오기
- 2. 다시 사용자 위도 경도와 긁어온 일의 위도 경도간의 `Haver-sine` 연산을 통해 거리 계산
- 3. MapStruct mapping을 활용해, ResponseDTO와 Entity, 계산한 거리를 Mapping

해당 로직은 **두 번의 Haver-sine 연산** 과 **불 필요한 Mapping**이 있어서 비효율적이었습니다.

이를 querydsl에서 거리 계산 직접 하기 + querydsl에서 바로 Mapping으로 바꾸어 효율을 극대화 하였습니다. 


# ✅ To Reviewers

# 📸 스크린샷
