### PR TITLE
FIX: FCM 양방향 송수신 설정 및 알림 저장 로직, 전 매칭 생애주기에 구현

### DIFF
--- a/src/main/java/spot/spot/domain/job/command/controller/WorkerCommandController.java
+++ b/src/main/java/spot/spot/domain/job/command/controller/WorkerCommandController.java
@@ -46,7 +46,7 @@ public class WorkerCommandController implements WorkerCommandDocs {
 
     @PostMapping("/continue")
     public void continueJob(@RequestBody ChangeStatusWorkerRequest request) {
-        workerCommandService.contiuneJob(request);
+        workerCommandService.continueJob(request);
     }
 
     @PostMapping(value = "/certificate", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/spot/spot/domain/job/command/dto/response/RegisterJobResponse.java
+++ b/src/main/java/spot/spot/domain/job/command/dto/response/RegisterJobResponse.java
@@ -5,14 +5,6 @@ import lombok.Builder;
 
 @Builder
 public record RegisterJobResponse(
-
         @NotNull(message = "잡 id는 빈 값일 수 없습니다.")
         Long jobId
-) {
-
-    public static RegisterJobResponse create(Long jobId) {
-        return RegisterJobResponse.builder()
-                .jobId(jobId)
-                .build();
-    }
-}
+) {}

--- a/src/main/java/spot/spot/domain/job/command/mapper/ClientCommandMapper.java
+++ b/src/main/java/spot/spot/domain/job/command/mapper/ClientCommandMapper.java
@@ -5,6 +5,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.mapstruct.*;
 import spot.spot.domain.job.command.dto.request.RegisterJobRequest;
+import spot.spot.domain.job.command.dto.response.RegisterJobResponse;
 import spot.spot.domain.job.command.entity.Job;
 import spot.spot.domain.job.command.entity.Matching;
 import spot.spot.domain.job.command.entity.MatchingStatus;
@@ -15,10 +16,12 @@ public interface ClientCommandMapper {
     // 1) 일 등록  (reqeust -> entity)
     @Mapping(target = "location", expression = "java(mapLatLngToPoint(request.lat(), request.lng(), geometryFactory))")
     Job registerRequestToJob (String img, RegisterJobRequest request, @Context GeometryFactory geometryFactory);
-
-    // 2. from DTO to Entity
+    // 2. from value to Matching
     @Mapping(target = "id", ignore = true)
     Matching toMatching (Member member, Job job, MatchingStatus status);
+    // 3. from value to JobRegisterResponse
+    @Mapping(target = "jobId", source = "id")
+    RegisterJobResponse toRegisterJobResponse(Long id);
 
     default Point mapLatLngToPoint(double lat, double lng, GeometryFactory geometryFactory) {
         Point ans =  geometryFactory.createPoint(new Coordinate(lng, lat));

--- a/src/main/java/spot/spot/domain/job/command/mapper/NotificationMapper.java
+++ b/src/main/java/spot/spot/domain/job/command/mapper/NotificationMapper.java
@@ -1,0 +1,18 @@
+package spot.spot.domain.job.command.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import spot.spot.domain.member.entity.Member;
+import spot.spot.domain.notification.command.dto.response.FcmDTO;
+import spot.spot.domain.notification.command.entity.NoticeType;
+import spot.spot.domain.notification.command.entity.Notification;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface NotificationMapper {
+
+    @Mapping(target = "member", source = "sender")
+    @Mapping(target = "content", source = "content")
+    @Mapping(target = "receiverId", source = "receiver_id")
+    Notification toNotification(FcmDTO fcmDTO, NoticeType type, Member sender, Long receiver_id);
+}

--- a/src/main/java/spot/spot/domain/job/command/service/ClientCommandService.java
+++ b/src/main/java/spot/spot/domain/job/command/service/ClientCommandService.java
@@ -62,8 +62,9 @@ public class ClientCommandService implements ClientCommandServiceDocs {
         Job job = jobRepository.save(clientCommandMapper.registerRequestToJob(url, request, geometryFactory));
         Matching matching = clientCommandMapper.toMatching(client, job, MatchingStatus.OWNER);
         matchingRepository.save(matching);
-        return RegisterJobResponse.create(job.getId());
+        return clientCommandMapper.toRegisterJobResponse(job.getId());
     }
+
 
     public void askingJob2Worker (ChangeStatusClientRequest request) {
         Member worker = memberRepository

--- a/src/main/java/spot/spot/domain/job/command/service/ClientCommandService.java
+++ b/src/main/java/spot/spot/domain/job/command/service/ClientCommandService.java
@@ -45,22 +45,22 @@ public class ClientCommandService implements ClientCommandServiceDocs {
     private final GeometryFactory geometryFactory;
     // Util
     private final UserAccessUtil userAccessUtil;
+    private final FcmAsyncSendingUtil fcmAsyncSendingUtil;
+    private final ReservationCancelUtil reservationCancelUtil;
+    private final FcmMessageUtil fcmMessageUtil;
     private final AwsS3ObjectStorage awsS3ObjectStorage;
+    private final PayService payService;
     // Mapper
     private final ClientCommandMapper clientCommandMapper;
-    private final JobRepository jobRepository;
+    private final NotificationMapper notificationMapper;
     // JPA
     private final MatchingRepository matchingRepository;
     private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+    private final MemberQueryRepository memberQueryRepository;
+    private final JobRepository jobRepository;
     // Query dsl
     private final ChangeJobStatusCommandDsl changeJobStatusCommandDsl;
-    private final FcmAsyncSendingUtil fcmAsyncSendingUtil;
-    private final PayService payService;
-    private final MemberRepository memberRepository;
-    private final ReservationCancelUtil reservationCancelUtil;
-    private final FcmMessageUtil fcmMessageUtil;
-    private final MemberQueryRepository memberQueryRepository;
-    private final NotificationMapper notificationMapper;
 
     public RegisterJobResponse registerJob(RegisterJobRequest request, MultipartFile file) {
         String url = awsS3ObjectStorage.uploadFile(file);
@@ -71,56 +71,64 @@ public class ClientCommandService implements ClientCommandServiceDocs {
         return clientCommandMapper.toRegisterJobResponse(job.getId());
     }
 
-
     public void askingJob2Worker (ChangeStatusClientRequest request) {
         Member worker = memberRepository.findById(request.workerId()).orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
         Job job = changeJobStatusCommandDsl.findJobWithValidation(request.workerId(), request.jobId());
-        Matching matching = Matching.builder().job(job).member(worker).status(MatchingStatus.REQUEST).build();
+        Matching matching = clientCommandMapper.toMatching(worker, job, MatchingStatus.REQUEST);
         matchingRepository.save(matching);
-        FcmDTO message = FcmDTO.create("일 해결 신청 알림!",  fcmMessageUtil.askRequest2WorkerMsg(worker.getNickname(), job.getTitle()));
-        fcmAsyncSendingUtil.singleFcmSend(worker.getId(), message);
-        notificationRepository.save(notificationMapper.toNotification(message, NoticeType.JOB, userAccessUtil.getMember(), worker.getId()));
+        FcmDTO msg = fcmMessageUtil.askingJob2WorkerMsg(userAccessUtil.getMember().getNickname(), worker.getNickname(), job.getTitle());
+        fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+        notificationRepository.save(notificationMapper.toNotification(msg, NoticeType.JOB, userAccessUtil.getMember(), worker.getId()));
     }
 
     @Transactional
     public void yesOrNo2RequestOfWorker(YesOrNoWorkersRequest request) {
         Member owner = userAccessUtil.getMember();
-        Member worker = memberRepository.findById(request.attenderId()).orElseThrow(() -> new GlobalException(
-            ErrorCode.MEMBER_NOT_FOUND));
+        Member worker = memberRepository.findById(request.attenderId()).orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
         Job job = changeJobStatusCommandDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.ATTENDER);
         changeJobStatusCommandDsl.updateMatchingStatus(worker.getId(), request.jobId(), request.isYes()? MatchingStatus.YES : MatchingStatus.NO);
-        FcmDTO message = FcmDTO.create("일 시작 알림!",  fcmMessageUtil.requestAcceptedBody(owner.getNickname(), worker.getNickname(), job.getTitle()));
-        fcmAsyncSendingUtil.singleFcmSend(worker.getId(), message);
-        notificationRepository.save(notificationMapper.toNotification(message,NoticeType.JOB,userAccessUtil.getMember(), worker.getId()));
+        FcmDTO msg = request.isYes()? fcmMessageUtil.sayYes2WorkerMsg(owner.getNickname(),
+            worker.getNickname(), job.getTitle()) : fcmMessageUtil.sayNo2WorkerMsg(owner.getNickname(),
+            worker.getNickname(), job.getTitle());
+        fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+        notificationRepository.save(notificationMapper.toNotification(msg, NoticeType.JOB, userAccessUtil.getMember(), worker.getId()));
     }
 
     @Transactional
     public void requestWithdrawal(ChangeStatusClientRequest request) {
         Member owner = userAccessUtil.getMember();
-        Member worker = memberRepository
-            .findById(request.workerId()).orElseThrow(() -> new GlobalException(
-                ErrorCode.MEMBER_NOT_FOUND));
+        Member worker = memberRepository.findById(request.workerId()).orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
         Job job = changeJobStatusCommandDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.START);
         Matching matching = changeJobStatusCommandDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.SLEEP);
         reservationCancelUtil.scheduledSleepMatching2Cancel(matching);
-        fcmAsyncSendingUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("혹시 잠수 타셨나요??").body(
-            fcmMessageUtil.requestAcceptedBody(owner.getNickname(), worker.getNickname(), job.getTitle())).build());
+        FcmDTO msg = fcmMessageUtil.doYouSleepMsg(owner.getNickname(), worker.getNickname(), job.getTitle());
+        fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+        notificationRepository.save(notificationMapper.toNotification(msg,NoticeType.JOB,owner, worker.getId()));
+    }
+
+    @Transactional
+    public void confirmOrRejectJob(ConfirmOrRejectRequest request) {
+        Member worker = memberQueryRepository.findOneFinisherOfJob(request.jobId()).orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
+        Job job = changeJobStatusCommandDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.FINISH);
+        Matching matching = changeJobStatusCommandDsl.updateMatchingStatus(worker.getId(), request.jobId(), request.isYes() ? MatchingStatus.CONFIRM : MatchingStatus.REJECT);
+
+        if (matching.getStatus().equals(MatchingStatus.CONFIRM)) {
+            payService.payTransfer(String.valueOf(worker.getId()),
+                payService.findPayAmountByMatchingJob(matching.getId(), worker.getId()),
+                matching.getJob());
+            FcmDTO msg = fcmMessageUtil.confirm2WorkerMsg(userAccessUtil.getMember().getNickname(),
+                worker.getNickname(), job.getTitle());
+            fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+        }else {
+            FcmDTO msg = fcmMessageUtil.reject2WorkerMsg(userAccessUtil.getMember().getNickname(),
+                worker.getNickname(), job.getTitle());
+            fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+        }
     }
 
     @Transactional
     public Job updateTidToJob(Job findJob, String tid) {
         findJob.setTid(tid);
         return findJob;
-    }
-
-    @Transactional
-    public void confirmOrRejectJob(ConfirmOrRejectRequest request) {
-        Member worker = memberQueryRepository.findOneFinisherOfJob(request.jobId()).orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
-        changeJobStatusCommandDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.FINISH);
-        Matching matching = changeJobStatusCommandDsl.updateMatchingStatus(worker.getId(), request.jobId(), request.isYes() ? MatchingStatus.CONFIRM : MatchingStatus.REJECT);
-        int payAmountByMatchingJob = payService.findPayAmountByMatchingJob(matching.getId(), worker.getId());
-        if (matching.getStatus().equals(MatchingStatus.CONFIRM)) {
-            payService.payTransfer(String.valueOf(worker.getId()), payAmountByMatchingJob, matching.getJob());
-        }
     }
 }

--- a/src/main/java/spot/spot/domain/job/command/service/WorkerCommandService.java
+++ b/src/main/java/spot/spot/domain/job/command/service/WorkerCommandService.java
@@ -59,7 +59,6 @@ public class WorkerCommandService implements WorkerCommandServiceDocs {
     private final CertificationRepository certificationRepository;
     private final ChangeJobStatusCommandDsl changeJobStatusCommandDsl;
     private final PayService payService;
-    private final MemberService memberService;
     private final FcmMessageUtil fcmMessageUtil;
     private final WorkerUpdatingCommandDsl workerUpdatingCommandDsl;
 

--- a/src/main/java/spot/spot/domain/job/command/service/_docs/WorkerCommandServiceDocs.java
+++ b/src/main/java/spot/spot/domain/job/command/service/_docs/WorkerCommandServiceDocs.java
@@ -16,7 +16,7 @@ public interface WorkerCommandServiceDocs {
     // 의뢰인이 보낸 요청 승낙하기 혹은 거절하기
     public void yesOrNo2RequestOfClient(YesOrNoClientsRequest request);
     // 일 재개 하기
-    public void contiuneJob(ChangeStatusWorkerRequest request);
+    public void continueJob(ChangeStatusWorkerRequest request);
     // 일 인증 사진 올리기
     public JobCertifiationResponse certificateJob(ChangeStatusWorkerRequest request, MultipartFile file);
     // 일 끝내기

--- a/src/main/java/spot/spot/domain/job/v1/command/service/ClientCommandVersion1Service.java
+++ b/src/main/java/spot/spot/domain/job/v1/command/service/ClientCommandVersion1Service.java
@@ -33,14 +33,8 @@ public class ClientCommandVersion1Service {
 
     @Transactional
     public void requestWithdrawalTest(ChangeStatusClientRequest request) {
-        Member owner = userAccessUtil.getMember();
-        Member worker = memberRepository
-            .findById(request.workerId()).orElseThrow(() -> new GlobalException(
-                ErrorCode.MEMBER_NOT_FOUND));
-        Job job = changeJobStatusCommandDsl.findJobWithValidation(worker.getId(), request.jobId(), MatchingStatus.START);
+        Member worker = memberRepository.findById(request.workerId()).orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
         Matching matching = changeJobStatusCommandDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.SLEEP);
         reservationCancelUtil.scheduledSleepMatching2CancelTest(matching);
-        fcmAsyncSendingUtil.singleFcmSend(worker.getId(), FcmDTO.builder().title("혹시 잠수 타셨나요??").body(
-            fcmMessageUtil.requestAcceptedBody(owner.getNickname(), worker.getNickname(), job.getTitle())).build());
     }
 }

--- a/src/main/java/spot/spot/domain/notification/command/dto/response/FcmDTO.java
+++ b/src/main/java/spot/spot/domain/notification/command/dto/response/FcmDTO.java
@@ -8,9 +8,4 @@ public record FcmDTO(
     @Schema(description = "알림의 제목", example = "박제가 되어버린 천재를 아시오?")
     String title,
     @Schema(description = "알림 본문", example = "직렬화 해서 안의 구조 꾸며도 괜춘!")
-    String body) {
-
-    public static FcmDTO create(String title, String body) {
-        return FcmDTO.builder().title(title).body(body).build();
-    }
-}
+    String body) { }

--- a/src/main/java/spot/spot/domain/notification/command/dto/response/FcmDTO.java
+++ b/src/main/java/spot/spot/domain/notification/command/dto/response/FcmDTO.java
@@ -10,4 +10,7 @@ public record FcmDTO(
     @Schema(description = "알림 본문", example = "직렬화 해서 안의 구조 꾸며도 괜춘!")
     String body) {
 
+    public static FcmDTO create(String title, String body) {
+        return FcmDTO.builder().title(title).body(body).build();
+    }
 }

--- a/src/main/java/spot/spot/domain/notification/command/service/FcmMessageUtil.java
+++ b/src/main/java/spot/spot/domain/notification/command/service/FcmMessageUtil.java
@@ -5,27 +5,56 @@ import spot.spot.domain.notification.command.dto.response.FcmDTO;
 
 @Component
 public class FcmMessageUtil {
+    public final StringBuilder msg = new StringBuilder();
 
-    public FcmDTO makeFcmDTO(String title, String body) {
+    public FcmDTO askingJob2WorkerMsg(String ownerName, String workerName, String jobTitle) {
+        msg.append(ownerName).append("님이 ").append(workerName).append("님께 ").append(jobTitle).append("을 신청하였습니다.");
+        FcmDTO fcm = makeMsg("일 의뢰 알림!",msg.toString());
+        msg.setLength(0);
+        return fcm;
+    }
+
+    public FcmDTO sayYes2WorkerMsg(String ownerName, String workerName, String jobTitle) {
+        msg.append(ownerName).append("님이 ").append(workerName).append("님의 ").append(jobTitle).append("해결 요청을 수락하셨습니다!");
+        FcmDTO fcm = makeMsg("일 신청 수락 알림", msg.toString());
+        msg.setLength(0);
+        return fcm;
+    }
+
+    public FcmDTO sayNo2WorkerMsg(String ownerName, String workerName, String jobTitle) {
+        msg.append(ownerName).append("님이 ").append(workerName).append("님의 ").append(jobTitle).append("해결 요청을 거절 하셨습니다.");
+        FcmDTO fcm = makeMsg("일 신청 거절 알림", msg.toString());
+        msg.setLength(0);
+        return fcm;
+    }
+
+    public FcmDTO doYouSleepMsg(String ownerName, String workerName, String jobTitle) {
+        msg.append(ownerName).append("님이 ").append(workerName).append("님의 ").append(jobTitle).append("해결 요청을 철회하길 원합니다.");
+        msg.append("/n 혹시 일을 재개하고 싶으시다면, 10분 내로 알려주세요!");
+        FcmDTO fcm = makeMsg("의뢰자로부터 예약 철회가 들어왔어요!", msg.toString());
+        msg.setLength(0);
+        return fcm;
+    }
+
+    public FcmDTO confirm2WorkerMsg(String ownerName, String workerName, String jobTitle) {
+        msg.append(ownerName).append("님이 ").append(workerName).append("님의 ").append(jobTitle).append("완료를 확정했습니다!");
+        FcmDTO fcm = makeMsg("일 완료 확정!", msg.toString());
+        msg.setLength(0);
+        return fcm;
+    }
+    public FcmDTO reject2WorkerMsg(String ownerName, String workerName, String jobTitle) {
+        msg.append(ownerName).append("님이 ").append(workerName).append("님의 ").append(jobTitle).append("완료를 거절했습니다.");
+        FcmDTO fcm = makeMsg("일 완료 거절! 다시 인증 바랍니다.", msg.toString());
+        msg.setLength(0);
+        return fcm;
+    }
+
+
+    private FcmDTO makeMsg(String title, String body) {
         return FcmDTO.builder()
             .title(title)
             .body(body)
             .build();
     }
 
-    public String askRequest2ClientMsg(String attenderName, String jobName){
-        return attenderName + "님이 " + jobName + "을 해결하길 원합니다!";
-    }
-
-    public String askRequest2WorkerMsg(String workerName, String jobName) {
-        return workerName + "님! " + jobName + "을 해결해 주십쇼!";
-    }
-
-    public String getStartedJobMsg(String attenderName, String jobName){
-        return attenderName + "님이 " + jobName + "을 시작합니다!";
-    }
-
-    public String requestAcceptedBody (String owner_name, String attender_name, String jobName){
-        return owner_name + "님이 " + jobName + "에 대한 " + attender_name + "님의 요청을 승낙하셨습니다!";
-    }
 }


### PR DESCRIPTION
# 💡 Issue
- close #210 

# 🌱 Key changes
- [x] 1. 의뢰인이 해결사에게 일 의뢰하는 요청 API 관련 알림 저장 로직 만들기
- [x] 2. 의뢰인이 해결사가 신청한 요청을 승낙하거나 거절하는 API 관련 알림 저장 로직 만들기
- [x] 3. 의뢰인이 취소 예약을 거는 API 관련 알림 저장 로직 만들기
- [x] 4. 의뢰인의 일 해결 완료를 승낙하거나 거절하는 API 관련 알림 저장 로직 만들기
- [x] 5. 의뢰인의 일 신청 API 관련 FCM 양방향 송수신 로직 만들기
- [x] 6. 의뢰인의 일 신청 API 관련 알림 저장 로직 만들기 
- [x] 7. 의뢰인의 일 시작하기 API 관련 FCM 양방향 송수신 로직 만들기
- [x] 8. 의뢰인의 일 시작하기 API 관련 알림 저장 로직 만들기
- [x] 9. 의뢰인의 요청 승낙 혹은 거절 API 관련 FCM 로직 만들기 
- [x] 10. 의뢰인의 요청 승낙 혹은 거절 API 관련 알림 저장 로직 만들기
- [x] 11. 의뢰인의 일 재개 요청 API 관련 FCM 로직 만들기
- [x] 12. 의뢰인의 일 재개 요청 API 관련 알림 저장 로직 만들기
- [x] 13. 의뢰인의 일 완료 신청 API 관련 FCM 로직 만들기
- [x] 14. 의뢰인의 일 완료 신청 API 관련 알림 저장 로직 만들기 

# ✅ To Reviewers

# 📸 스크린샷
