### PR TITLE
FIX: 일 완료 버튼 안되는 것 수정

### DIFF
--- a/src/main/java/spot/spot/domain/job/command/service/WorkerCommandService.java
+++ b/src/main/java/spot/spot/domain/job/command/service/WorkerCommandService.java
@@ -153,7 +153,8 @@ public class WorkerCommandService implements WorkerCommandServiceDocs {
         changeJobStatusCommandDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.FINISH);
         Job job = jobRepository.findById(matching.getJob().getId()).orElseThrow(()-> new GlobalException(ErrorCode.JOB_NOT_FOUND));
 
-        Member owner = changeJobStatusCommandDsl.getJobsOwner(matching.getId());
+        Member owner = changeJobStatusCommandDsl.getJobsOwner(job.getId());
+        log.info( "{}, {} ",owner.getId(), owner.getNickname());
         FcmDTO msg = fcmMessageUtil.startJob2ClientMsg(owner.getNickname(), worker.getNickname(), job.getTitle());
         fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
         notificationRepository.save(notificationMapper.toNotification(msg,NoticeType.JOB, worker, owner.getId()));

--- a/src/main/java/spot/spot/domain/job/command/service/WorkerCommandService.java
+++ b/src/main/java/spot/spot/domain/job/command/service/WorkerCommandService.java
@@ -154,7 +154,6 @@ public class WorkerCommandService implements WorkerCommandServiceDocs {
         Job job = jobRepository.findById(matching.getJob().getId()).orElseThrow(()-> new GlobalException(ErrorCode.JOB_NOT_FOUND));
 
         Member owner = changeJobStatusCommandDsl.getJobsOwner(job.getId());
-        log.info( "{}, {} ",owner.getId(), owner.getNickname());
         FcmDTO msg = fcmMessageUtil.startJob2ClientMsg(owner.getNickname(), worker.getNickname(), job.getTitle());
         fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
         notificationRepository.save(notificationMapper.toNotification(msg,NoticeType.JOB, worker, owner.getId()));


### PR DESCRIPTION
# 💡 Issue
- #237 

# 🌱 Key changes
- [ ] ```java
        Member owner = changeJobStatusCommandDsl.getJobsOwner(job.getId());
        FcmDTO msg = fcmMessageUtil.startJob2ClientMsg(owner.getNickname(), worker.getNickname(), job.getTitle());
        ```
        이 부분에서 job.getId() 가 아니라 matching.getId()를 보내고 있었습니다.

# ✅ To Reviewers
시나리오 테스트를 하며, 알림 수정으로 인해 생겼던 오류를 잡았습니다. 

# 📸 스크린샷
