### PR TITLE
FEAT: Thread 거절에 대한 재시도 로직 에서 지연 변이 로직 추가

### DIFF
--- a/src/main/java/spot/spot/domain/job/command/service/ClientCommandService.java
+++ b/src/main/java/spot/spot/domain/job/command/service/ClientCommandService.java
@@ -3,6 +3,7 @@ package spot.spot.domain.job.command.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -50,6 +51,7 @@ public class ClientCommandService implements ClientCommandServiceDocs {
     private final FcmMessageUtil fcmMessageUtil;
     private final AwsS3ObjectStorage awsS3ObjectStorage;
     private final PayService payService;
+    private final RetryTemplate retryTemplate;
     // Mapper
     private final ClientCommandMapper clientCommandMapper;
     private final NotificationMapper notificationMapper;
@@ -77,7 +79,11 @@ public class ClientCommandService implements ClientCommandServiceDocs {
         Matching matching = clientCommandMapper.toMatching(worker, job, MatchingStatus.REQUEST);
         matchingRepository.save(matching);
         FcmDTO msg = fcmMessageUtil.askingJob2WorkerMsg(userAccessUtil.getMember().getNickname(), worker.getNickname(), job.getTitle());
-        fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+        retryTemplate.execute(context -> {
+            log.warn("해결사에게 일 의뢰: FCM 전송 시도 [재시도 횟수 {}]", context.getRetryCount());
+            fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+            return null;
+        });
         notificationRepository.save(notificationMapper.toNotification(msg, NoticeType.JOB, userAccessUtil.getMember(), worker.getId()));
     }
 
@@ -90,7 +96,11 @@ public class ClientCommandService implements ClientCommandServiceDocs {
         FcmDTO msg = request.isYes()? fcmMessageUtil.sayYes2WorkerMsg(owner.getNickname(),
             worker.getNickname(), job.getTitle()) : fcmMessageUtil.sayNo2WorkerMsg(owner.getNickname(),
             worker.getNickname(), job.getTitle());
-        fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+        retryTemplate.execute(context -> {
+            log.warn("의뢰인의 일 해결 요청: FCM 전송 시도 [재시도 횟수 {}]", context.getRetryCount());
+            fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+            return null;
+        });
         notificationRepository.save(notificationMapper.toNotification(msg, NoticeType.JOB, userAccessUtil.getMember(), worker.getId()));
     }
 
@@ -102,7 +112,11 @@ public class ClientCommandService implements ClientCommandServiceDocs {
         Matching matching = changeJobStatusCommandDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.SLEEP);
         reservationCancelUtil.scheduledSleepMatching2Cancel(matching);
         FcmDTO msg = fcmMessageUtil.doYouSleepMsg(owner.getNickname(), worker.getNickname(), job.getTitle());
-        fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+        retryTemplate.execute(context -> {
+            log.warn("해결사 취소 요청 (NO SHOW): FCM 전송 시도 [재시도 횟수 {}]", context.getRetryCount());
+            fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+            return null;
+        });
         notificationRepository.save(notificationMapper.toNotification(msg,NoticeType.JOB,owner, worker.getId()));
     }
 
@@ -118,11 +132,19 @@ public class ClientCommandService implements ClientCommandServiceDocs {
                 matching.getJob());
             FcmDTO msg = fcmMessageUtil.confirm2WorkerMsg(userAccessUtil.getMember().getNickname(),
                 worker.getNickname(), job.getTitle());
-            fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+            retryTemplate.execute(context -> {
+                log.warn("해결사 확정 재시도 : FCM 전송 시도 [재시도 횟수 {}]", context.getRetryCount());
+                fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+                return null;
+            });
         }else {
             FcmDTO msg = fcmMessageUtil.reject2WorkerMsg(userAccessUtil.getMember().getNickname(),
                 worker.getNickname(), job.getTitle());
-            fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+            retryTemplate.execute(context -> {
+                log.warn("해결사 거절 재시도: FCM 전송 시도 [재시도 횟수 {}]", context.getRetryCount());
+                fcmAsyncSendingUtil.singleFcmSend(worker.getId(), msg);
+                return null;
+            });
         }
     }
 

--- a/src/main/java/spot/spot/domain/job/command/service/WorkerCommandService.java
+++ b/src/main/java/spot/spot/domain/job/command/service/WorkerCommandService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -55,6 +56,7 @@ public class WorkerCommandService implements WorkerCommandServiceDocs {
     private final WorkerCommandMapper workerCommandMapper;
     private final AwsS3ObjectStorage awsS3ObjectStorage;
     private final ReservationCancelUtil reservationCancelUtil;
+    private final RetryTemplate retryTemplate;
     // Repo
     private final WorkerRepository workerRepository;
     private final AbilityRepository abilityRepository;
@@ -86,7 +88,11 @@ public class WorkerCommandService implements WorkerCommandServiceDocs {
         matchingRepository.save(matching);
         Member owner = changeJobStatusCommandDsl.getJobsOwner(job.getId());
         FcmDTO msg = fcmMessageUtil.askingJob2ClientMsg(owner.getNickname(), worker.getNickname(),job.getTitle());
-        fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
+        retryTemplate.execute(context -> {
+            log.warn("의뢰인의 일 해결 요청: FCM 전송 시도 [재시도 횟수 {}]", context.getRetryCount());
+            fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
+            return  null;
+        });
         notificationRepository.save(notificationMapper.toNotification(msg, NoticeType.JOB, worker, owner.getId()));
     }
 
@@ -98,7 +104,11 @@ public class WorkerCommandService implements WorkerCommandServiceDocs {
         changeJobStatusCommandDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.START);
         Member owner = changeJobStatusCommandDsl.getJobsOwner(job.getId());
         FcmDTO msg = fcmMessageUtil.startJob2ClientMsg(owner.getNickname(), worker.getNickname(), job.getTitle());
-        fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
+        retryTemplate.execute(context -> {
+            log.warn("해결사의 일 시작 [재시도 횟수 {}]", context.getRetryCount());
+            fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
+            return  null;
+        });
         notificationRepository.save(notificationMapper.toNotification(msg,NoticeType.JOB, worker,
             owner.getId()));
     }
@@ -112,7 +122,11 @@ public class WorkerCommandService implements WorkerCommandServiceDocs {
         FcmDTO msg = request.isYes()?
             fcmMessageUtil.sayYes2ClientMsg(owner.getNickname(), worker.getNickname(), job.getTitle()) :
             fcmMessageUtil.sayNo2ClientMsg(owner.getNickname(), worker.getNickname(), job.getTitle());
-        fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
+        retryTemplate.execute(context -> {
+            log.warn("해결사의 일 의뢰 승낙 혹은 거절 [재시도 횟수 {}]", context.getRetryCount());
+            fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
+            return  null;
+        });
         notificationRepository.save(notificationMapper.toNotification(msg,NoticeType.JOB, worker,
             owner.getId()));
     }
@@ -123,10 +137,13 @@ public class WorkerCommandService implements WorkerCommandServiceDocs {
         Matching matching = matchingRepository.findByMemberAndJob_Id(worker, request.jobId()).orElseThrow(() -> new GlobalException(ErrorCode.MATCHING_NOT_FOUND));
         reservationCancelUtil.withdrawalExistingScheduledTask(matching.getId());
         changeJobStatusCommandDsl.updateMatchingStatus(worker.getId(), request.jobId(), MatchingStatus.START);
-
         Member owner = changeJobStatusCommandDsl.getJobsOwner(matching.getId());
         FcmDTO msg = fcmMessageUtil.continueJobMsg(owner.getNickname(), worker.getNickname());
-        fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
+        retryTemplate.execute(context -> {
+            log.warn("해결사의 일 재개 [재시도 횟수 {}]", context.getRetryCount());
+            fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
+            return  null;
+        });
         notificationRepository.save(notificationMapper.toNotification(msg,NoticeType.JOB, worker,
             owner.getId()));
     }
@@ -155,7 +172,11 @@ public class WorkerCommandService implements WorkerCommandServiceDocs {
 
         Member owner = changeJobStatusCommandDsl.getJobsOwner(matching.getId());
         FcmDTO msg = fcmMessageUtil.startJob2ClientMsg(owner.getNickname(), worker.getNickname(), job.getTitle());
-        fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
+        retryTemplate.execute(context -> {
+            log.warn("해결사의 일 성공 알림 [재시도 횟수 {}]", context.getRetryCount());
+            fcmAsyncSendingUtil.singleFcmSend(owner.getId(), msg);
+            return  null;
+        });
         notificationRepository.save(notificationMapper.toNotification(msg,NoticeType.JOB, worker, owner.getId()));
     }
 

--- a/src/main/java/spot/spot/domain/notification/command/service/FcmAsyncSendingUtil.java
+++ b/src/main/java/spot/spot/domain/notification/command/service/FcmAsyncSendingUtil.java
@@ -29,11 +29,6 @@ public class FcmAsyncSendingUtil {
     // 회원 한 명과 관련된 FCM 토큰에 메시지를 보내는 기능
 
     @Async("taskExecutor")
-    @Retryable(
-        retryFor = RejectedExecutionException.class,
-        maxAttempts = 3,
-        backoff = @Backoff(delay = 1000, multiplier = 2.0, maxDelay = 5000)
-    )
     public void singleFcmSend(long receiverId,  FcmDTO fcmDTO) {
         fcmTokenRepository.findAllByMember_Id(receiverId)
             .stream()

--- a/src/main/java/spot/spot/global/retry/ExponentialJitterBackOffPolicy.java
+++ b/src/main/java/spot/spot/global/retry/ExponentialJitterBackOffPolicy.java
@@ -10,16 +10,16 @@ import org.springframework.retry.backoff.BackOffInterruptedException;
 import org.springframework.retry.backoff.BackOffPolicy;
 
 @Slf4j
-public class ExponentialJitterBackOffPolicy implements BackOffPolicy { // 전략 클래스 - 어떻게 재시도 할지 전략만 정의
+public class ExponentialJitterBackOffPolicy implements BackOffPolicy {
 
-    private final long initialInterval = 1000L;
-    private double multiplier = 2.0;
-    private long maxInterval = 10000L;
+    // BACK-OFF POLICY: 전략 클래스 - 어떻게 재시도 할지 전략만 정의
+    // BACK-OFF CONTEXT: 상태 클래스 -> 개별 재시도 루틴마다의 상태를 기록 후 저장
+
     private final Random random = new Random();
 
     @Override
     public BackOffContext start(RetryContext retryContext) {
-        return new ExponentialJitterBackOffContext(initialInterval, multiplier, maxInterval);
+        return new ExponentialJitterBackOffContext(1000L, 2.0, 5000L);
     }
 
     @Override
@@ -33,7 +33,7 @@ public class ExponentialJitterBackOffPolicy implements BackOffPolicy { // 전략
                 // 현재 스레드 인터럽트 상태 복구 (권장 패턴)
                 Thread.currentThread().interrupt();
                 // 로그 남기기
-                log.warn("Backoff sleep interrupted: {}", e.getMessage());
+                log.warn("다른 쓰레드가 잠든 쓰레드를 깨워버렸습니다. {}", e.getMessage());
             }
 
             long next = (long) (ctx.currentInterval * ctx.multiplier);
@@ -41,8 +41,7 @@ public class ExponentialJitterBackOffPolicy implements BackOffPolicy { // 전략
         }
     }
 
-    @Setter
-    private static class ExponentialJitterBackOffContext implements BackOffContext {  // 상태 클래스 -> 개별 재시도 루틴마다의 상태를 기록 후 저장
+    private static class ExponentialJitterBackOffContext implements BackOffContext {
         private long currentInterval;
         private final double multiplier;
         private final long maxInterval;
@@ -52,8 +51,6 @@ public class ExponentialJitterBackOffPolicy implements BackOffPolicy { // 전략
             this.multiplier = multiplier;
             this.maxInterval = maxInterval;
         }
-
-
     }
 
 

--- a/src/main/java/spot/spot/global/retry/RetryConfig.java
+++ b/src/main/java/spot/spot/global/retry/RetryConfig.java
@@ -17,18 +17,14 @@ public class RetryConfig {
     @Bean
     public RetryTemplate retryTemplate() {
         RetryTemplate template = new RetryTemplate();
+        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(3,
+            Map.of(
+                RejectedExecutionException.class, true
+            ));
 
-        Map<Class<? extends Throwable>, Boolean> retryable = Map.of(
-            RejectedExecutionException.class, true
-        );
-        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(3, retryable);
-
-        ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
-        backOffPolicy.setInitialInterval(1000);
-        backOffPolicy.setMultiplier(2.0);
-        backOffPolicy.setMaxInterval(5000);
+        ExponentialJitterBackOffPolicy jitterPolicy = new ExponentialJitterBackOffPolicy();
         template.setRetryPolicy(retryPolicy);
-        template.setBackOffPolicy(backOffPolicy);
+        template.setBackOffPolicy(jitterPolicy);
 
         return template;
     }


### PR DESCRIPTION
# 💡 Issue
- resolve #261 

# 🌱 Key changes
- [x] 재시도 로직에 지연 변이 알고리즘을 추가했습니다.
![image](https://github.com/user-attachments/assets/245c860f-6406-4b69-8ee9-36ac26a8e9ff)


지수 백오프 동안 동시에 요청이 들어온다면, 같은 지수 시간에 동시에 요청을 하기 때문에, 동시성에 따른 큐 진입 실패자들의 동시 요청을 분산하진 못하고 뒤로 미루는 느낌입니다.

여기에 난수 알고리즘을 통한 지연 변이를 넣어서, 재시도 요청의 시간대를 세밀하게 분산하도록 조치 했습니다. 

# ✅ To Reviewers

# 📸 스크린샷
