### PR TITLE
CHORE: Thread Connection Time Out 시간 60초로 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,7 @@ server:
     accept-count: 1000
     mbeanregistry:
       enabled: true
+    connection-timeout: 60000
 
 # SWAGGER
 springdoc:


### PR DESCRIPTION
# 💡 Issue
- none

# 🌱 Key changes
- [x] AWS 로드 밸런서의 Connection TimeOut이 60초인데, Thread 타임아웃이 20초여서, 부하 테스트 시 이로 인한 TIME-OUT이 났습니다. 따라서, 로드밸러스와 같은 시간대인 60초 늘렸습니다. 

# ✅ To Reviewers

# 📸 스크린샷
